### PR TITLE
Merge upstream v2.26.0

### DIFF
--- a/cmd/template_lagoonservices.go
+++ b/cmd/template_lagoonservices.go
@@ -145,6 +145,20 @@ func LagoonServiceTemplateGeneration(g generator.GeneratorInput) error {
 		}
 		helpers.WriteTemplateFile(fmt.Sprintf("%s/isolation-network-policy.yaml", savedTemplates), templateBytes)
 	}
+	serviceNetPols, err := servicestemplates.GenerateServiceNetworkPolicies(*lagoonBuild.BuildValues)
+	if err != nil {
+		return fmt.Errorf("couldn't generate template: %v", err)
+	}
+	for _, serviceNetPol := range serviceNetPols {
+		templateBytes, err := servicestemplates.TemplateNetworkPolicy(&serviceNetPol)
+		if err != nil {
+			return fmt.Errorf("couldn't generate template: %v", err)
+		}
+		if g.Debug {
+			fmt.Printf("Templating networkpolicy manifests %s\n", fmt.Sprintf("%s/networkpolicy-%s.yaml", savedTemplates, serviceNetPol.Name))
+		}
+		helpers.WriteTemplateFile(fmt.Sprintf("%s/networkpolicy-%s.yaml", savedTemplates, serviceNetPol.Name), templateBytes)
+	}
 	return nil
 }
 

--- a/cmd/template_lagoonservices_test.go
+++ b/cmd/template_lagoonservices_test.go
@@ -627,6 +627,38 @@ func TestTemplateLagoonServices(t *testing.T) {
 			templatePath: "testoutput",
 			want:         "internal/testdata/basic/service-templates/test-basic-single-k8upv2",
 		},
+		{
+			name:        "test-basic-external-service",
+			description: "tests a basic deployment with a basic and an external service and network policy to share a service",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "main",
+					Branch:          "main",
+					LagoonYAML:      "internal/testdata/basic/lagoon.externalservice.yml",
+					ImageReferences: map[string]string{
+						"basic1": "harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/test-basic-external-service",
+		},
+		{
+			name:        "test-basic-external-service-environment",
+			description: "tests a basic deployment with a basic and an external service and network policy to share when defined under the environment",
+			args: testdata.GetSeedData(
+				testdata.TestData{
+					ProjectName:     "example-project",
+					EnvironmentName: "stage",
+					Branch:          "stage",
+					LagoonYAML:      "internal/testdata/basic/lagoon.externalservice.yml",
+					ImageReferences: map[string]string{
+						"basic1": "harbor.example/example-project/stage/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8",
+					},
+				}, true),
+			templatePath: "testoutput",
+			want:         "internal/testdata/basic/service-templates/test-basic-external-service-environment",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -37,6 +37,7 @@ type LagoonEnvState struct {
 	MariaDBConsumers      *mariadbv1.MariaDBConsumerList     `json:"mariadbconsumers"`
 	MongoDBConsumers      *mongodbv1.MongoDBConsumerList     `json:"mongodbconsumers"`
 	PostgreSQLConsumers   *postgresv1.PostgreSQLConsumerList `json:"postgresqlconsumers"`
+	NetworkPolicies       *networkv1.NetworkPolicyList       `json:"networkpolicies"`
 }
 
 func NewCollector(client client.Client) *Collector {
@@ -127,6 +128,10 @@ func (c *Collector) Collect(ctx context.Context, namespace string) (*LagoonEnvSt
 			fmt.Fprintln(os.Stderr, err)
 			return nil, err
 		}
+	}
+	state.NetworkPolicies, err = c.CollectNetworkPolicies(ctx, namespace)
+	if err != nil {
+		return nil, err
 	}
 	return &state, nil
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -32,7 +32,7 @@ func TestCollector_Collect(t *testing.T) {
 				namespace: "example-project-main",
 			},
 			seedDir: "testdata/seed/seed-1",
-			want:    "testdata/result/result-1/",
+			want:    "testdata/result/result-1",
 			wantErr: false,
 		},
 		{
@@ -42,7 +42,17 @@ func TestCollector_Collect(t *testing.T) {
 				namespace: "example-project-main",
 			},
 			seedDir: "testdata/seed/seed-2",
-			want:    "testdata/result/result-2/",
+			want:    "testdata/result/result-2",
+			wantErr: false,
+		},
+		{
+			name: "list-environment-netpol",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-3",
+			want:    "testdata/result/result-3",
 			wantErr: false,
 		},
 	}
@@ -64,84 +74,65 @@ func TestCollector_Collect(t *testing.T) {
 				t.Errorf("Collector.Collect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			results, err := os.ReadDir(tt.want)
-			if err != nil {
-				t.Errorf("couldn't read directory %v: %v", tt.want, err)
+			if len(got.Deployments.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-deployments.yaml"), got.Deployments)
 			}
-			for _, r := range results {
-				var rBytes []byte
-				switch r.Name() {
-				case "lagoon-deployments.yaml":
-					rBytes, err = yaml.Marshal(got.Deployments)
-					if err != nil {
-						t.Errorf("couldn't marshal deployments: %v", err)
-					}
-				case "lagoon-cronjobs.yaml":
-					rBytes, err = yaml.Marshal(got.Cronjobs)
-					if err != nil {
-						t.Errorf("couldn't marshal cronjobs: %v", err)
-					}
-				case "lagoon-ingress.yaml":
-					rBytes, err = yaml.Marshal(got.Ingress)
-					if err != nil {
-						t.Errorf("couldn't marshal ingress: %v", err)
-					}
-				case "lagoon-services.yaml":
-					rBytes, err = yaml.Marshal(got.Services)
-					if err != nil {
-						t.Errorf("couldn't marshal services: %v", err)
-					}
-				case "lagoon-secrets.yaml":
-					rBytes, err = yaml.Marshal(got.Secrets)
-					if err != nil {
-						t.Errorf("couldn't marshal secrets: %v", err)
-					}
-				case "lagoon-mariadb-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.MariaDBConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal mariadb-consumers: %v", err)
-					}
-				case "lagoon-mongodb-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.MongoDBConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal mongodb-consumers: %v", err)
-					}
-				case "lagoon-postgres-consumers.yaml":
-					rBytes, err = yaml.Marshal(got.PostgreSQLConsumers)
-					if err != nil {
-						t.Errorf("couldn't marshal postgres-consumers: %v", err)
-					}
-				case "lagoon-schedules-v1.yaml":
-					rBytes, err = yaml.Marshal(got.SchedulesV1)
-					if err != nil {
-						t.Errorf("couldn't marshal schedules-v1: %v", err)
-					}
-				case "lagoon-schedules-v1alpha1.yaml":
-					rBytes, err = yaml.Marshal(got.SchedulesV1Alpha1)
-					if err != nil {
-						t.Errorf("couldn't marshal schedules-v1alpha1: %v", err)
-					}
-				case "lagoon-prebackuppods-v1.yaml":
-					rBytes, err = yaml.Marshal(got.PreBackupPodsV1)
-					if err != nil {
-						t.Errorf("couldn't marshal prebackuppods-v1: %v", err)
-					}
-				case "lagoon-prebackuppods-v1alpha1.yaml":
-					rBytes, err = yaml.Marshal(got.PreBackupPodsV1Alpha1)
-					if err != nil {
-						t.Errorf("couldn't marshal prebackuppods-v1alpha1: %v", err)
-					}
-				default:
-					continue
-				}
-				r1, err := os.ReadFile(fmt.Sprintf("%s/%s", tt.want, r.Name()))
-				if err != nil {
-					t.Errorf("couldn't read file %v: %v", fmt.Sprintf("%s/%s", tt.want, r.Name()), err)
-				}
-				if !reflect.DeepEqual(rBytes, r1) {
-					t.Errorf("Collect() = \n%v", diff.LineDiff(string(r1), string(rBytes)))
-				}
+			if len(got.Cronjobs.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-cronjobs.yaml"), got.Cronjobs)
+			}
+			if len(got.Ingress.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-ingress.yaml"), got.Ingress)
+			}
+			if len(got.Services.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-services.yaml"), got.Services)
+			}
+			if len(got.Secrets.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-secrets.yaml"), got.Secrets)
+			}
+			if len(got.MariaDBConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-mariadb-consumers.yaml"), got.MariaDBConsumers)
+			}
+			if len(got.MongoDBConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-mongodb-consumers.yaml"), got.MongoDBConsumers)
+			}
+			if len(got.PostgreSQLConsumers.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-postgres-consumers.yaml"), got.PostgreSQLConsumers)
+			}
+			if len(got.SchedulesV1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-schedules-v1.yaml"), got.SchedulesV1)
+			}
+			if len(got.SchedulesV1Alpha1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-schedules-v1alpha1.yaml"), got.SchedulesV1Alpha1)
+			}
+			if len(got.PreBackupPodsV1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-prebackuppods-v1.yaml"), got.PreBackupPodsV1)
+			}
+			if len(got.PreBackupPodsV1Alpha1.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-prebackuppods-v1alpha1.yaml"), got.PreBackupPodsV1Alpha1)
+			}
+			if len(got.NetworkPolicies.Items) > 0 {
+				checkResult(t, fmt.Sprintf("%s/%s", tt.want, "lagoon-networkpolicies.yaml"), got.NetworkPolicies)
 			}
 		})
+	}
+}
+
+func checkResult(t *testing.T, want string, got interface{}) {
+	rBytes, err := yaml.Marshal(got)
+	if err != nil {
+		t.Errorf("couldn't marshal deployments: %v", err)
+	}
+	r1, err := os.ReadFile(want)
+	if err != nil {
+		// try create the file if it doesn't exist
+		err := os.WriteFile(want, rBytes, 0644)
+		if err != nil {
+			t.Errorf("couldn't write file %v: %v", want, err)
+		} else {
+			t.Errorf("couldn't read file %v: %v", want, err)
+		}
+	}
+	if !reflect.DeepEqual(rBytes, r1) {
+		t.Errorf("Collect() = \n%v", diff.LineDiff(string(r1), string(rBytes)))
 	}
 }

--- a/internal/collector/networkpolicies.go
+++ b/internal/collector/networkpolicies.go
@@ -1,0 +1,26 @@
+package collector
+
+import (
+	"context"
+
+	networkv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (c *Collector) CollectNetworkPolicies(ctx context.Context, namespace string) (*networkv1.NetworkPolicyList, error) {
+	labelRequirements1, _ := labels.NewRequirement("lagoon.sh/service", selection.Exists, nil)
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(*labelRequirements1),
+		},
+	})
+	list := &networkv1.NetworkPolicyList{}
+	err := c.Client.List(ctx, list, listOption)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}

--- a/internal/collector/networkpolicies_test.go
+++ b/internal/collector/networkpolicies_test.go
@@ -1,0 +1,80 @@
+package collector
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"github.com/uselagoon/build-deploy-tool/internal/k8s"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCollector_CollectNetworkPolicies(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		seedDir string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "new-environment",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-empty",
+			want:    "testdata/result/result-empty/lagoon-networkpolicies.yaml",
+			wantErr: false,
+		},
+		{
+			name: "list-services",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "example-project-main",
+			},
+			seedDir: "testdata/seed/seed-1",
+			want:    "testdata/result/result-1/lagoon-networkpolicies.yaml",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := k8s.NewFakeClient(tt.args.namespace)
+			if err != nil {
+				t.Errorf("error creating fake client")
+			}
+			err = k8s.SeedFakeData(client, tt.args.namespace, tt.seedDir)
+			if err != nil {
+				t.Errorf("error seeding fake data: %v", err)
+			}
+			c := &Collector{
+				Client: client,
+			}
+			got, err := c.CollectNetworkPolicies(tt.args.ctx, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collector.CollectNetworkPolicies() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			oJ, _ := yaml.Marshal(got)
+			results, err := os.ReadFile(tt.want)
+			if err != nil {
+				// try create the file if it doesn't exist
+				err := os.WriteFile(tt.want, oJ, 0644)
+				if err != nil {
+					t.Errorf("couldn't write file %v: %v", tt.want, err)
+				} else {
+					t.Errorf("couldn't read file %v: %v", tt.want, err)
+				}
+			}
+			if string(oJ) != string(results) {
+				t.Errorf("Collector.CollectNetworkPolicies() = \n%v", diff.LineDiff(string(results), string(oJ)))
+			}
+		})
+	}
+}

--- a/internal/collector/testdata/json-result/result-1.json
+++ b/internal/collector/testdata/json-result/result-1.json
@@ -721,5 +721,9 @@
   "postgresqlconsumers": {
     "metadata": {},
     "items": []
+  },
+  "networkpolicies": {
+    "metadata": {},
+    "items": []
   }
 }

--- a/internal/collector/testdata/json-result/result-2.json
+++ b/internal/collector/testdata/json-result/result-2.json
@@ -436,5 +436,9 @@
   "postgresqlconsumers": {
     "metadata": {},
     "items": []
+  },
+  "networkpolicies": {
+    "metadata": {},
+    "items": []
   }
 }

--- a/internal/collector/testdata/result/result-1/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-1/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-2/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-2/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-cronjobs.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-cronjobs.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-deployments.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-deployments.yaml
@@ -1,0 +1,89 @@
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: basic
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: basic
+      lagoon.sh/template: basic-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/name: basic
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          lagoon.sh/branch: main
+          lagoon.sh/configMapSha: abcdefg1234567890
+          lagoon.sh/version: v2.7.x
+        creationTimestamp: null
+        labels:
+          app.kubernetes.io/instance: basic1
+          app.kubernetes.io/managed-by: build-deploy-tool
+          app.kubernetes.io/name: basic
+          lagoon.sh/buildType: branch
+          lagoon.sh/environment: main
+          lagoon.sh/environmentType: production
+          lagoon.sh/project: example-project
+          lagoon.sh/service: basic1
+          lagoon.sh/service-type: basic
+          lagoon.sh/template: basic-0.1.0
+      spec:
+        automountServiceAccountToken: false
+        containers:
+        - env:
+          - name: LAGOON_GIT_SHA
+            value: abcdefg123456
+          - name: CRONJOBS
+          - name: SERVICE_NAME
+            value: basic1
+          envFrom:
+          - secretRef:
+              name: lagoon-platform-env
+          - secretRef:
+              name: lagoon-env
+          image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+          imagePullPolicy: Always
+          livenessProbe:
+            initialDelaySeconds: 60
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 10
+          name: basic
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          readinessProbe:
+            initialDelaySeconds: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+          securityContext: {}
+        enableServiceLinks: false
+        imagePullSecrets:
+        - name: lagoon-internal-registry-secret
+        priorityClassName: lagoon-priority-production
+  status: {}
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-ingress.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-ingress.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-mariadb-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-mariadb-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-mongodb-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-mongodb-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-networkpolicies.yaml
@@ -1,0 +1,85 @@
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: service-network-policy
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: service-network-policy
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: network-policy
+      lagoon.sh/template: service-network-policy-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    ingress:
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: lagoon.sh/project
+            operator: In
+            values:
+            - my-project
+          - key: lagoon.sh/environment
+            operator: In
+            values:
+            - main
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: lagoon.sh/project
+            operator: In
+            values:
+            - my-other-project
+          - key: lagoon.sh/environmentType
+            operator: In
+            values:
+            - production
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - nameoforg
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - anotherorg
+          - key: lagoon.sh/environmentType
+            operator: In
+            values:
+            - production
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchExpressions:
+          - key: organization.lagoon.sh/name
+            operator: In
+            values:
+            - someotherorg
+          - key: lagoon.sh/project
+            operator: NotIn
+            values:
+            - projecta
+            - projectb
+    podSelector:
+      matchLabels:
+        lagoon.sh/service: basic1
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-postgres-consumers.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-postgres-consumers.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1alpha1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-prebackuppods-v1alpha1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-schedules-v1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-schedules-v1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-schedules-v1alpha1.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-schedules-v1alpha1.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-secrets.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-secrets.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/result/result-3/lagoon-services.yaml
+++ b/internal/collector/testdata/result/result-3/lagoon-services.yaml
@@ -1,0 +1,86 @@
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: basic
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic1
+      lagoon.sh/service-type: basic
+      lagoon.sh/template: basic-0.1.0
+    name: basic1
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    selector:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic2
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: external
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic2
+      lagoon.sh/service-type: external
+      lagoon.sh/template: external-0.1.0
+    name: basic2
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    externalName: basic.other-project-main.svc.cluster.local
+    type: ExternalName
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      lagoon.sh/branch: main
+      lagoon.sh/version: v2.7.x
+    creationTimestamp: null
+    labels:
+      app.kubernetes.io/instance: basic3
+      app.kubernetes.io/managed-by: build-deploy-tool
+      app.kubernetes.io/name: external
+      lagoon.sh/buildType: branch
+      lagoon.sh/environment: main
+      lagoon.sh/environmentType: production
+      lagoon.sh/project: example-project
+      lagoon.sh/service: basic3
+      lagoon.sh/service-type: external
+      lagoon.sh/template: external-0.1.0
+    name: basic3
+    namespace: example-project-main
+    resourceVersion: "1"
+  spec:
+    externalName: some-domain.example.com
+    type: ExternalName
+  status:
+    loadBalancer: {}
+metadata: {}

--- a/internal/collector/testdata/result/result-empty/lagoon-networkpolicies.yaml
+++ b/internal/collector/testdata/result/result-empty/lagoon-networkpolicies.yaml
@@ -1,0 +1,2 @@
+items: []
+metadata: {}

--- a/internal/collector/testdata/seed/seed-3/deployment-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/collector/testdata/seed/seed-3/networkpolicy-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/networkpolicy-basic1.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project
+        - key: lagoon.sh/environment
+          operator: In
+          values:
+          - main
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-other-project
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - nameoforg
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - anotherorg
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - someotherorg
+        - key: lagoon.sh/project
+          operator: NotIn
+          values:
+          - projecta
+          - projectb
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/collector/testdata/seed/seed-3/service-basic1.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/collector/testdata/seed/seed-3/service-basic2.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/collector/testdata/seed/seed-3/service-basic3.yaml
+++ b/internal/collector/testdata/seed/seed-3/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -209,6 +209,14 @@ type ServiceValues struct {
 	IsSingle                               bool                    `json:"isSingle"`
 	AdditionalVolumes                      []ServiceVolume         `json:"additonalVolumes,omitempty"`
 	CreateDefaultVolume                    bool                    `json:"createDefaultVolume"`
+	ExternalServiceName                    string                  `json:"externalServiceName,omitempty"`
+}
+
+type ExternalService struct {
+	Name        string `json:"name,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Domain      string `json:"domain,omitempty"`
 }
 
 type ImageBuild struct {

--- a/internal/generator/buildvalues.go
+++ b/internal/generator/buildvalues.go
@@ -89,7 +89,8 @@ type BuildValues struct {
 	ConfigSSHHost                 string                       `json:"configSSHHost"`
 	ConfigSSHPort                 string                       `json:"configSSHPort"`
 	LagoonEnvVariables            map[string]string            `json:"lagoonEnvVariables" description:"map of variables that will be saved into the lagoon-env secret"`
-	LagoonPlatformEnvVariables    map[string]string            `json:"agoonPlatformEnvVariables" description:"map of variables that will be saved into the lagoon-platform-env secret"`
+	LagoonPlatformEnvVariables    map[string]string            `json:"lagoonPlatformEnvVariables" description:"map of variables that will be saved into the lagoon-platform-env secret"`
+	AutoMountServiceAccountToken  bool                         `json:"autoMountServiceAccountToken" description:"flag to enable automounting the service account token"`
 }
 
 type Resources struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -352,6 +352,8 @@ func NewGenerator(
 	buildValues.Resources.Limits.Memory = CheckAdminFeatureFlag("CONTAINER_MEMORY_LIMIT", false)
 	buildValues.Resources.Limits.EphemeralStorage = CheckAdminFeatureFlag("EPHEMERAL_STORAGE_LIMIT", false)
 	buildValues.Resources.Requests.EphemeralStorage = CheckAdminFeatureFlag("EPHEMERAL_STORAGE_REQUESTS", false)
+	automount, _ := strconv.ParseBool(CheckAdminFeatureFlag("AUTOMOUNT_SERVICE_ACCOUNT_TOKEN", false))
+	buildValues.AutoMountServiceAccountToken = automount
 	// validate that what is provided
 	if buildValues.Resources.Limits.Memory != "" {
 		err := ValidateResourceQuantity(buildValues.Resources.Limits.Memory)

--- a/internal/generator/services.go
+++ b/internal/generator/services.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
 	"github.com/uselagoon/build-deploy-tool/internal/servicetypes"
+	machinerynamespace "github.com/uselagoon/machinery/utils/namespace"
 )
 
 // this is a map that maps old service types to their new service types
@@ -278,131 +280,9 @@ func composeToServiceValues(
 		}
 		// anything after this point is where heavy processing is done as the service type has now been determined by this stage
 
-		// handle dbaas operator checks here
-		dbaasEnvironment := buildValues.EnvironmentType
 		svcIsDBaaS := false
 		svcIsSingle := false
-		if helpers.Contains(supportedDBTypes, lagoonType) {
-			// strip the dbaas off the supplied type for checking against providers, it gets added again later
-			lagoonType = strings.Split(lagoonType, "-dbaas")[0]
-			err := buildValues.DBaaSClient.CheckHealth(buildValues.DBaaSOperatorEndpoint)
-			if err != nil {
-				// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
-				// if !buildValues.DBaaSFallbackSingle {
-				// 	return nil, fmt.Errorf("unable to check the DBaaS endpoint %s: %v", buildValues.DBaaSOperatorEndpoint, err)
-				// }
-				if debug {
-					fmt.Printf("Unable to check the DBaaS endpoint %s, falling back to %s-single: %v\n", buildValues.DBaaSOperatorEndpoint, lagoonType, err)
-				}
-				// normally we would fall back to doing a cluster capability check, this is phased out in the build tool, it isn't reliable
-				// and noone should be doing checks that way any more
-				// the old bash check is the following
-				// elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]] && ! checkDBaaSHealth ; then
-				lagoonType = fmt.Sprintf("%s-single", lagoonType)
-			} else {
-				// if there is a `lagoon.%s-dbaas.environment` label on this service, this should be used as an the environment type for the dbaas
-				dbaasLabelOverride := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, fmt.Sprintf("lagoon.%s-dbaas.environment", lagoonType))
-				if dbaasLabelOverride != "" {
-					dbaasEnvironment = dbaasLabelOverride
-				}
-
-				// @TODO: maybe phase this out?
-				// if value, ok := buildValues.LagoonYAML.Environments[buildValues.Environment].Overrides[composeService][mariadb][mariadb-dbaas].Environment; ok {
-				// this isn't documented in the lagoon.yml, and it looks like a failover from days past.
-				// 	lagoonType = value
-				// }
-
-				// if there are overrides defined in the lagoon API `LAGOON_DBAAS_ENVIRONMENT_TYPES`
-				// handle those here
-				exists, err := getDBaasEnvironment(buildValues, &dbaasEnvironment, lagoonOverrideName, lagoonType)
-				if err != nil {
-					// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
-					// if !buildValues.DBaaSFallbackSingle {
-					// 	return nil, err
-					// }
-					if debug {
-						fmt.Printf(
-							"There was an error checking DBaaS endpoint %s, falling back to %s-single: %v\n",
-							buildValues.DBaaSOperatorEndpoint, lagoonType, err,
-						)
-					}
-				}
-
-				// if the requested dbaas environment exists, then set the type to be the requested type with `-dbaas`
-				if exists {
-					lagoonType = fmt.Sprintf("%s-dbaas", lagoonType)
-					svcIsDBaaS = true
-				} else {
-					// otherwise fallback to -single (if DBaaSFallbackSingle is enabled, otherwise it will error out prior)
-					lagoonType = fmt.Sprintf("%s-single", lagoonType)
-					svcIsSingle = true
-				}
-			}
-		}
-
-		// check if the service has any persistent labels, this is the path that the volume will be mounted to
-		servicePersistentPath := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent")
-		if servicePersistentPath == "" {
-			// if there is no persistent path, check if the service type has a default path
-			if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
-				servicePersistentPath = val.Volumes.PersistentVolumePath
-				// check if the service type provides or consumes a default persistent volume
-				if (val.ProvidesPersistentVolume || val.ConsumesPersistentVolume) && servicePersistentPath == "" {
-					return nil, fmt.Errorf("label lagoon.persistent not defined for service %s, no valid mount path was found", composeService)
-				}
-			}
-		}
-		servicePersistentName := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.name")
-		if servicePersistentName == "" && servicePersistentPath != "" {
-			// if there is a persistent path defined, then set the persistent name to be the compose service if no persistent name is provided
-			// persistent name is used by joined services like nginx/php or cli or worker pods to mount another service volume
-			servicePersistentName = lagoonOverrideName
-		}
-		servicePersistentSize := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.size")
-		if servicePersistentSize == "" {
-			// if there is no persistent size, check if the service type has a default size allocated
-			if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
-				servicePersistentSize = val.Volumes.PersistentVolumeSize
-				// check if the service type provides persistent volume, and that a size was detected
-				if val.ProvidesPersistentVolume && servicePersistentSize == "" {
-					return nil, fmt.Errorf("label lagoon.persistent.size not defined for service %s, no valid size was found", composeService)
-				}
-			}
-		}
-		if servicePersistentSize != "" {
-			// check the provided size is a valid resource size for kubernetes
-			_, err := ValidateResourceSize(servicePersistentSize)
-			if err != nil {
-				return nil, fmt.Errorf("provided persistent volume size for %s is not valid: %v", servicePersistentName, err)
-			}
-		}
-
-		// if any `lagoon.base.image` labels are set, we note them for docker pulling
-		// this allows us to refresh the docker-host's cache in cases where an image
-		// may have an update without a change in tag (i.e. "latest" tagged images)
-		baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
-		if baseimage != "" {
-			baseImageWithTag, errs := determineRefreshImage(composeService, baseimage, buildValues.EnvironmentVariables)
-			if len(errs) > 0 {
-				for idx, err := range errs {
-					if idx+1 == len(errs) {
-						return nil, err
-					} else {
-						fmt.Println(err)
-					}
-				}
-			}
-			buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
-		}
-
-		// calculate if this service needs any additional volumes attached from the calculated build volumes
-		// additional volumes can only be attached to certain
-		serviceVolumes, err := calculateServiceVolumes(buildValues, lagoonType, servicePersistentName, composeServiceValues.Labels)
-		if err != nil {
-			return nil, err
-		}
-
-		// start spot instance handling
+		backupsEnabled := false
 		useSpot := false
 		forceSpot := false
 		cronjobUseSpot := false
@@ -410,142 +290,292 @@ func composeToServiceValues(
 		spotTypes := ""
 		cronjobSpotTypes := ""
 		spotReplicas := int32(0)
-
-		// these services can support multiple replicas in production
-		// @TODO this should probably be an admin only feature flag though
-		prodSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_PRODUCTION", debug)
-		if prodSpotReplicaTypes == "" {
-			prodSpotReplicaTypes = "nginx,nginx-persistent,nginx-php,nginx-php-persistent"
-		}
-		devSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_DEVELOPMENT", debug)
-		if devSpotReplicaTypes == "" {
-			devSpotReplicaTypes = ""
-		}
-
-		productionSpot := CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION", buildValues.EnvironmentVariables, debug)
-		developmentSpot := CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT", buildValues.EnvironmentVariables, debug)
-		if productionSpot == "enabled" && buildValues.EnvironmentType == "production" {
-			spotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_TYPES", buildValues.EnvironmentVariables, debug)
-			cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
-		}
-		if developmentSpot == "enabled" && buildValues.EnvironmentType == "development" {
-			spotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_TYPES", buildValues.EnvironmentVariables, debug)
-			cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
-		}
-		// check if the provided spot instance types against the current lagoonType
-		for _, t := range strings.Split(spotTypes, ",") {
-			if t != "" {
-				tt := strings.Split(t, ":")
-				if tt[0] == lagoonType {
-					useSpot = true
-					// check if the length of the split is more than one indicating that `force` is provided
-					if len(tt) > 1 && tt[1] == "force" {
-						forceSpot = true
-					}
-				}
-			}
-		}
-		// check if the provided cronjob spot instance types against the current lagoonType
-		for _, t := range strings.Split(cronjobSpotTypes, ",") {
-			if t != "" {
-				tt := strings.Split(t, ":")
-				if tt[0] == lagoonType {
-					cronjobUseSpot = true
-					// check if the length of the split is more than one indicating that `force` is provided
-					if len(tt) > 1 && tt[1] == "force" {
-						cronjobForceSpot = true
-					}
-				}
-			}
-		}
-		// check if the this service is production and can support 2 replicas on spot
-		for _, t := range strings.Split(prodSpotReplicaTypes, ",") {
-			if t != "" {
-				if t == lagoonType && buildValues.EnvironmentType == "production" && useSpot {
-					spotReplicas = 2
-				}
-			}
-		}
-		for _, t := range strings.Split(devSpotReplicaTypes, ",") {
-			if t != "" {
-				if t == lagoonType && buildValues.EnvironmentType == "development" && useSpot {
-					spotReplicas = 2
-				}
-			}
-		}
-		// end spot instance handling
-
-		// work out cronjobs for this service
+		servicePersistentPath := ""
+		servicePersistentName := ""
+		servicePersistentSize := ""
 		inpodcronjobs := []lagoon.Cronjob{}
 		nativecronjobs := []lagoon.Cronjob{}
-		// check if there are any duplicate named cronjobs
-		if err := checkDuplicateCronjobs(buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs); err != nil {
-			return nil, err
-		}
-		if !buildValues.CronjobsDisabled {
-			for idx, cronjob := range buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs {
-				// if this cronjob is meant for this service, add it
-				if cronjob.Service == composeService {
-					var err error
-					inpod, err := helpers.IsInPodCronjob(cronjob.Schedule)
+		dbaasEnvironment := buildValues.EnvironmentType
+		externalName := ""
+		var serviceVolumes []ServiceVolume
+		var err error
+		if lagoonType == "external" {
+			esLabel := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.external.service")
+			if esLabel == "" {
+				return nil, fmt.Errorf(
+					"lagoon.type external has been set for service %s, yet no 'lagoon.external.service' label was defined",
+					composeService,
+				)
+			}
+			externalService := &ExternalService{}
+			if err := json.Unmarshal([]byte(esLabel), externalService); err != nil {
+				return nil, fmt.Errorf(
+					"error encountered decoding label 'lagoon.external.service' for service %s, is it JSON?",
+					composeService,
+				)
+			}
+			if externalService.Domain == "" {
+				externalName = fmt.Sprintf("%s.%s.svc.cluster.local", externalService.Name, machinerynamespace.GenerateNamespaceName("", externalService.Environment, externalService.Project, "", "", false))
+			} else {
+				externalName = externalService.Domain
+			}
+		} else {
+			// handle dbaas operator checks here
+			if helpers.Contains(supportedDBTypes, lagoonType) {
+				// strip the dbaas off the supplied type for checking against providers, it gets added again later
+				lagoonType = strings.Split(lagoonType, "-dbaas")[0]
+				err := buildValues.DBaaSClient.CheckHealth(buildValues.DBaaSOperatorEndpoint)
+				if err != nil {
+					// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
+					// if !buildValues.DBaaSFallbackSingle {
+					// 	return nil, fmt.Errorf("unable to check the DBaaS endpoint %s: %v", buildValues.DBaaSOperatorEndpoint, err)
+					// }
+					if debug {
+						fmt.Printf("Unable to check the DBaaS endpoint %s, falling back to %s-single: %v\n", buildValues.DBaaSOperatorEndpoint, lagoonType, err)
+					}
+					// normally we would fall back to doing a cluster capability check, this is phased out in the build tool, it isn't reliable
+					// and noone should be doing checks that way any more
+					// the old bash check is the following
+					// elif [[ "${CAPABILITIES[@]}" =~ "mariadb.amazee.io/v1/MariaDBConsumer" ]] && ! checkDBaaSHealth ; then
+					lagoonType = fmt.Sprintf("%s-single", lagoonType)
+				} else {
+					// if there is a `lagoon.%s-dbaas.environment` label on this service, this should be used as an the environment type for the dbaas
+					dbaasLabelOverride := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, fmt.Sprintf("lagoon.%s-dbaas.environment", lagoonType))
+					if dbaasLabelOverride != "" {
+						dbaasEnvironment = dbaasLabelOverride
+					}
+
+					// @TODO: maybe phase this out?
+					// if value, ok := buildValues.LagoonYAML.Environments[buildValues.Environment].Overrides[composeService][mariadb][mariadb-dbaas].Environment; ok {
+					// this isn't documented in the lagoon.yml, and it looks like a failover from days past.
+					// 	lagoonType = value
+					// }
+
+					// if there are overrides defined in the lagoon API `LAGOON_DBAAS_ENVIRONMENT_TYPES`
+					// handle those here
+					exists, err := getDBaasEnvironment(buildValues, &dbaasEnvironment, lagoonOverrideName, lagoonType)
 					if err != nil {
-						return nil, fmt.Errorf("unable to validate crontab for cronjob %s: %v", cronjob.Name, err)
-					}
-					cronjob.Schedule, err = helpers.ConvertCrontab(buildValues.Namespace, cronjob.Schedule)
-					if err != nil {
-						return nil, fmt.Errorf("unable to convert crontab for cronjob %s: %v", cronjob.Name, err)
-					}
-					// handle setting the cronjob timeout here
-					// can't be greater than 24hrs and must match go time duration https://pkg.go.dev/time#ParseDuration
-					if cronjob.Timeout != "" {
-						cronjobTimeout, err := time.ParseDuration(cronjob.Timeout)
-						if err != nil {
-							return nil, fmt.Errorf("unable to convert timeout for cronjob %s: %v", cronjob.Name, err)
+						// @TODO eventually this error should be handled and fail a build, with a flag to override https://github.com/uselagoon/build-deploy-tool/issues/56
+						// if !buildValues.DBaaSFallbackSingle {
+						// 	return nil, err
+						// }
+						if debug {
+							fmt.Printf(
+								"There was an error checking DBaaS endpoint %s, falling back to %s-single: %v\n",
+								buildValues.DBaaSOperatorEndpoint, lagoonType, err,
+							)
 						}
-						// max cronjob timeout is 24 hours
-						if cronjobTimeout > time.Duration(24*time.Hour) {
-							return nil, fmt.Errorf("timeout for cronjob %s cannot be longer than 24 hours", cronjob.Name)
-						}
+					}
+
+					// if the requested dbaas environment exists, then set the type to be the requested type with `-dbaas`
+					if exists {
+						lagoonType = fmt.Sprintf("%s-dbaas", lagoonType)
+						svcIsDBaaS = true
 					} else {
-						// default cronjob timeout is 4h
-						cronjob.Timeout = "4h"
-					}
-					// if the cronjob is inpod, or the cronjob has an inpod flag override
-					if inpod || (cronjob.InPod != nil && *cronjob.InPod) {
-						cmd := cronjob.Command
-						// Lagoon enforces that only a single instance of a cronjob can run at any one time.
-						// https://man7.org/linux/man-pages/man1/flock.1.html
-						// https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
-						sha := sha256.New()
-						sha.Write([]byte(fmt.Sprintf("%d %s", idx, cmd)))
-						cmdSha := sha.Sum(nil)
-						cronjob.Command = fmt.Sprintf("flock -n /tmp/cron.lock.%x -c %s", cmdSha, shellescape.Quote(cmd))
-						inpodcronjobs = append(inpodcronjobs, cronjob)
-					} else {
-						// make the cronjob name kubernetes compliant
-						cronjob.Name = regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(fmt.Sprintf("cronjob-%s-%s", lagoonOverrideName, strings.ToLower(cronjob.Name)), "-")
-						if len(cronjob.Name) > 52 {
-							// if the cronjob name is longer than 52 characters
-							// truncate it and add a hash of the name to it
-							cronjob.Name = fmt.Sprintf("%s-%s", cronjob.Name[:45], helpers.GetBase32EncodedLowercase(helpers.GetSha256Hash(cronjob.Name))[:6])
-						}
-						nativecronjobs = append(nativecronjobs, cronjob)
+						// otherwise fallback to -single (if DBaaSFallbackSingle is enabled, otherwise it will error out prior)
+						lagoonType = fmt.Sprintf("%s-single", lagoonType)
+						svcIsSingle = true
 					}
 				}
 			}
-		}
 
-		// check if this service is one that supports autogenerated routes
-		if !helpers.Contains(supportedAutogeneratedTypes, lagoonType) {
-			autogenEnabled = false
-			autogenTLSAcmeEnabled = false
-		}
+			// check if the service has any persistent labels, this is the path that the volume will be mounted to
+			servicePersistentPath = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent")
+			if servicePersistentPath == "" {
+				// if there is no persistent path, check if the service type has a default path
+				if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
+					servicePersistentPath = val.Volumes.PersistentVolumePath
+					// check if the service type provides or consumes a default persistent volume
+					if (val.ProvidesPersistentVolume || val.ConsumesPersistentVolume) && servicePersistentPath == "" {
+						return nil, fmt.Errorf("label lagoon.persistent not defined for service %s, no valid mount path was found", composeService)
+					}
+				}
+			}
+			servicePersistentName = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.name")
+			if servicePersistentName == "" && servicePersistentPath != "" {
+				// if there is a persistent path defined, then set the persistent name to be the compose service if no persistent name is provided
+				// persistent name is used by joined services like nginx/php or cli or worker pods to mount another service volume
+				servicePersistentName = lagoonOverrideName
+			}
+			servicePersistentSize = lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.persistent.size")
+			if servicePersistentSize == "" {
+				// if there is no persistent size, check if the service type has a default size allocated
+				if val, ok := servicetypes.ServiceTypes[lagoonType]; ok {
+					servicePersistentSize = val.Volumes.PersistentVolumeSize
+					// check if the service type provides persistent volume, and that a size was detected
+					if val.ProvidesPersistentVolume && servicePersistentSize == "" {
+						return nil, fmt.Errorf("label lagoon.persistent.size not defined for service %s, no valid size was found", composeService)
+					}
+				}
+			}
+			if servicePersistentSize != "" {
+				// check the provided size is a valid resource size for kubernetes
+				_, err := ValidateResourceSize(servicePersistentSize)
+				if err != nil {
+					return nil, fmt.Errorf("provided persistent volume size for %s is not valid: %v", servicePersistentName, err)
+				}
+			}
 
-		// check if this service is one that supports backups
-		backupsEnabled := false
-		if helpers.Contains(typesWithBackups, lagoonType) {
-			backupsEnabled = true
+			// if any `lagoon.base.image` labels are set, we note them for docker pulling
+			// this allows us to refresh the docker-host's cache in cases where an image
+			// may have an update without a change in tag (i.e. "latest" tagged images)
+			baseimage := lagoon.CheckDockerComposeLagoonLabel(composeServiceValues.Labels, "lagoon.base.image")
+			if baseimage != "" {
+				baseImageWithTag, errs := determineRefreshImage(composeService, baseimage, buildValues.EnvironmentVariables)
+				if len(errs) > 0 {
+					for idx, err := range errs {
+						if idx+1 == len(errs) {
+							return nil, err
+						} else {
+							fmt.Println(err)
+						}
+					}
+				}
+				buildValues.ForcePullImages = append(buildValues.ForcePullImages, baseImageWithTag)
+			}
 
+			// calculate if this service needs any additional volumes attached from the calculated build volumes
+			// additional volumes can only be attached to certain
+			serviceVolumes, err = calculateServiceVolumes(buildValues, lagoonType, servicePersistentName, composeServiceValues.Labels)
+			if err != nil {
+				return nil, err
+			}
+
+			// start spot instance handling
+
+			// these services can support multiple replicas in production
+			// @TODO this should probably be an admin only feature flag though
+			prodSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_PRODUCTION", debug)
+			if prodSpotReplicaTypes == "" {
+				prodSpotReplicaTypes = "nginx,nginx-persistent,nginx-php,nginx-php-persistent"
+			}
+			devSpotReplicaTypes := CheckAdminFeatureFlag("SPOT_TYPE_REPLICAS_DEVELOPMENT", debug)
+			if devSpotReplicaTypes == "" {
+				devSpotReplicaTypes = ""
+			}
+
+			productionSpot := CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION", buildValues.EnvironmentVariables, debug)
+			developmentSpot := CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT", buildValues.EnvironmentVariables, debug)
+			if productionSpot == "enabled" && buildValues.EnvironmentType == "production" {
+				spotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_TYPES", buildValues.EnvironmentVariables, debug)
+				cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_PRODUCTION_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
+			}
+			if developmentSpot == "enabled" && buildValues.EnvironmentType == "development" {
+				spotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_TYPES", buildValues.EnvironmentVariables, debug)
+				cronjobSpotTypes = CheckFeatureFlag("SPOT_INSTANCE_DEVELOPMENT_CRONJOB_TYPES", buildValues.EnvironmentVariables, debug)
+			}
+			// check if the provided spot instance types against the current lagoonType
+			for _, t := range strings.Split(spotTypes, ",") {
+				if t != "" {
+					tt := strings.Split(t, ":")
+					if tt[0] == lagoonType {
+						useSpot = true
+						// check if the length of the split is more than one indicating that `force` is provided
+						if len(tt) > 1 && tt[1] == "force" {
+							forceSpot = true
+						}
+					}
+				}
+			}
+			// check if the provided cronjob spot instance types against the current lagoonType
+			for _, t := range strings.Split(cronjobSpotTypes, ",") {
+				if t != "" {
+					tt := strings.Split(t, ":")
+					if tt[0] == lagoonType {
+						cronjobUseSpot = true
+						// check if the length of the split is more than one indicating that `force` is provided
+						if len(tt) > 1 && tt[1] == "force" {
+							cronjobForceSpot = true
+						}
+					}
+				}
+			}
+			// check if the this service is production and can support 2 replicas on spot
+			for _, t := range strings.Split(prodSpotReplicaTypes, ",") {
+				if t != "" {
+					if t == lagoonType && buildValues.EnvironmentType == "production" && useSpot {
+						spotReplicas = 2
+					}
+				}
+			}
+			for _, t := range strings.Split(devSpotReplicaTypes, ",") {
+				if t != "" {
+					if t == lagoonType && buildValues.EnvironmentType == "development" && useSpot {
+						spotReplicas = 2
+					}
+				}
+			}
+			// end spot instance handling
+
+			// work out cronjobs for this service
+			// check if there are any duplicate named cronjobs
+			if err := checkDuplicateCronjobs(buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs); err != nil {
+				return nil, err
+			}
+			if !buildValues.CronjobsDisabled {
+				for idx, cronjob := range buildValues.LagoonYAML.Environments[buildValues.Branch].Cronjobs {
+					// if this cronjob is meant for this service, add it
+					if cronjob.Service == composeService {
+						var err error
+						inpod, err := helpers.IsInPodCronjob(cronjob.Schedule)
+						if err != nil {
+							return nil, fmt.Errorf("unable to validate crontab for cronjob %s: %v", cronjob.Name, err)
+						}
+						cronjob.Schedule, err = helpers.ConvertCrontab(buildValues.Namespace, cronjob.Schedule)
+						if err != nil {
+							return nil, fmt.Errorf("unable to convert crontab for cronjob %s: %v", cronjob.Name, err)
+						}
+						// handle setting the cronjob timeout here
+						// can't be greater than 24hrs and must match go time duration https://pkg.go.dev/time#ParseDuration
+						if cronjob.Timeout != "" {
+							cronjobTimeout, err := time.ParseDuration(cronjob.Timeout)
+							if err != nil {
+								return nil, fmt.Errorf("unable to convert timeout for cronjob %s: %v", cronjob.Name, err)
+							}
+							// max cronjob timeout is 24 hours
+							if cronjobTimeout > time.Duration(24*time.Hour) {
+								return nil, fmt.Errorf("timeout for cronjob %s cannot be longer than 24 hours", cronjob.Name)
+							}
+						} else {
+							// default cronjob timeout is 4h
+							cronjob.Timeout = "4h"
+						}
+						// if the cronjob is inpod, or the cronjob has an inpod flag override
+						if inpod || (cronjob.InPod != nil && *cronjob.InPod) {
+							cmd := cronjob.Command
+							// Lagoon enforces that only a single instance of a cronjob can run at any one time.
+							// https://man7.org/linux/man-pages/man1/flock.1.html
+							// https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion
+							sha := sha256.New()
+							sha.Write([]byte(fmt.Sprintf("%d %s", idx, cmd)))
+							cmdSha := sha.Sum(nil)
+							cronjob.Command = fmt.Sprintf("flock -n /tmp/cron.lock.%x -c %s", cmdSha, shellescape.Quote(cmd))
+							inpodcronjobs = append(inpodcronjobs, cronjob)
+						} else {
+							// make the cronjob name kubernetes compliant
+							cronjob.Name = regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(fmt.Sprintf("cronjob-%s-%s", lagoonOverrideName, strings.ToLower(cronjob.Name)), "-")
+							if len(cronjob.Name) > 52 {
+								// if the cronjob name is longer than 52 characters
+								// truncate it and add a hash of the name to it
+								cronjob.Name = fmt.Sprintf("%s-%s", cronjob.Name[:45], helpers.GetBase32EncodedLowercase(helpers.GetSha256Hash(cronjob.Name))[:6])
+							}
+							nativecronjobs = append(nativecronjobs, cronjob)
+						}
+					}
+				}
+			}
+
+			// check if this service is one that supports autogenerated routes
+			if !helpers.Contains(supportedAutogeneratedTypes, lagoonType) {
+				autogenEnabled = false
+				autogenTLSAcmeEnabled = false
+			}
+
+			// check if this service is one that supports backups
+			if helpers.Contains(typesWithBackups, lagoonType) {
+				backupsEnabled = true
+
+			}
 		}
 
 		// create the service values
@@ -572,6 +602,7 @@ func composeToServiceValues(
 			IsSingle:                               svcIsSingle,
 			BackupsEnabled:                         backupsEnabled,
 			AdditionalVolumes:                      serviceVolumes,
+			ExternalServiceName:                    externalName,
 		}
 
 		// work out the images here and the associated dockerfile and contexts

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -131,10 +131,9 @@ type NetworkPolicy struct {
 }
 
 type OrgNetworkPolicies struct {
-	Name                string           `json:"name"`
-	EnvironmentType     string           `json:"environment-type,omitempty"`
-	ExcludeProjects     []ExcludeProject `json:"exclude-projects,omitempty"`
-	ExcludePullrequests bool             `json:"exclude-pullrequests,omitempty"`
+	Name            string           `json:"name"`
+	EnvironmentType string           `json:"environment-type,omitempty"`
+	ExcludeProjects []ExcludeProject `json:"exclude-projects,omitempty"`
 }
 
 type ProjectNetworkPolicies struct {

--- a/internal/lagoon/lagoon.go
+++ b/internal/lagoon/lagoon.go
@@ -26,6 +26,7 @@ type Environment struct {
 	Cronjobs               []Cronjob               `json:"cronjobs"`
 	Overrides              map[string]Override     `json:"overrides,omitempty"`
 	AutogeneratePathRoutes []AutogeneratePathRoute `json:"autogeneratePathRoutes,omitempty"`
+	NetworkPolicies        []NetworkPolicy         `json:"network-policies,omitempty"`
 }
 
 // Cronjob represents a Lagoon cronjob.
@@ -73,6 +74,7 @@ type YAML struct {
 	BackupSchedule       BackupSchedule               `json:"backup-schedule"`
 	EnvironmentVariables EnvironmentVariables         `json:"environment_variables,omitempty"`
 	ContainerRegistries  map[string]ContainerRegistry `json:"container-registries,omitempty"`
+	NetworkPolicies      []NetworkPolicy              `json:"network-policies,omitempty"`
 }
 
 type ContainerRegistry struct {
@@ -120,6 +122,35 @@ type Autogenerate struct {
 type AutogeneratePathRoute struct {
 	PathRoute
 	FromService string `json:"fromService"`
+}
+
+type NetworkPolicy struct {
+	Service       string                   `json:"service"`
+	Organizations []OrgNetworkPolicies     `json:"organizations"`
+	Projects      []ProjectNetworkPolicies `json:"projects"`
+}
+
+type OrgNetworkPolicies struct {
+	Name                string           `json:"name"`
+	EnvironmentType     string           `json:"environment-type,omitempty"`
+	ExcludeProjects     []ExcludeProject `json:"exclude-projects,omitempty"`
+	ExcludePullrequests bool             `json:"exclude-pullrequests,omitempty"`
+}
+
+type ProjectNetworkPolicies struct {
+	Name                string               `json:"name"`
+	Environment         string               `json:"environment,omitempty"`
+	EnvironmentType     string               `json:"environment-type,omitempty"`
+	ExcludeEnvironments []ExcludeEnvironment `json:"exclude-environments,omitempty"`
+	ExcludePullrequests bool                 `json:"exclude-pullrequests,omitempty"`
+}
+
+type ExcludeProject struct {
+	Name string `json:"name"`
+}
+
+type ExcludeEnvironment struct {
+	Name string `json:"name"`
 }
 
 func (a *Routes) UnmarshalJSON(data []byte) error {

--- a/internal/servicetypes/external.go
+++ b/internal/servicetypes/external.go
@@ -1,0 +1,7 @@
+package servicetypes
+
+// defines an external service type
+// this type doesn't have any associated data so this just acts as a placeholder
+var external = ServiceType{
+	Name: "external",
+}

--- a/internal/servicetypes/node.go
+++ b/internal/servicetypes/node.go
@@ -57,8 +57,11 @@ var node = ServiceType{
 						},
 					},
 				},
+				TimeoutSeconds: 10,
+				// Wait 180 seconds before liveness probe fails.
 				InitialDelaySeconds: 60,
-				TimeoutSeconds:      10,
+				PeriodSeconds:       10,
+				FailureThreshold:    12,
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{

--- a/internal/servicetypes/redis.go
+++ b/internal/servicetypes/redis.go
@@ -79,6 +79,12 @@ var redisPersistent = ServiceType{
 	PrimaryContainer: ServiceContainer{
 		Name:      redis.PrimaryContainer.Name,
 		Container: redis.PrimaryContainer.Container,
+		EnvVars: []corev1.EnvVar{
+			{
+				Name:  "REDIS_FLAVOR",
+				Value: "persistent",
+			},
+		},
 	},
 	Volumes: ServiceVolume{
 		PersistentVolumeSize: "5Gi",

--- a/internal/servicetypes/types.go
+++ b/internal/servicetypes/types.go
@@ -88,4 +88,5 @@ var ServiceTypes = map[string]ServiceType{
 	"worker":               worker,
 	"worker-persistent":    workerPersistent,
 	"rabbitmq":             rabbitmq,
+	"external":             external,
 }

--- a/internal/templating/template_networkpolicy.go
+++ b/internal/templating/template_networkpolicy.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/uselagoon/build-deploy-tool/internal/generator"
+	"github.com/uselagoon/build-deploy-tool/internal/lagoon"
+	machineryns "github.com/uselagoon/machinery/utils/namespace"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -76,6 +78,87 @@ func GenerateNetworkPolicy(
 	return &np, nil
 }
 
+// GenerateServiceNetworkPolicies will generate any networkpolicies required for specific services if defined in the lagoon.yml file
+func GenerateServiceNetworkPolicies(
+	buildValues generator.BuildValues,
+) ([]networkv1.NetworkPolicy, error) {
+	var nps []networkv1.NetworkPolicy
+
+	// default is to set the network policies to whatever is at the root of the lagoon.yml if provided
+	lagoonNetworkPolicies := buildValues.LagoonYAML.NetworkPolicies
+	// check if the environment has specific network policies, these should be used instead
+	// they aren't stacked or added to the root network policies, they will replace them
+	if buildValues.LagoonYAML.Environments[buildValues.Environment].NetworkPolicies != nil {
+		lagoonNetworkPolicies = buildValues.LagoonYAML.Environments[buildValues.Environment].NetworkPolicies
+	}
+	if lagoonNetworkPolicies != nil {
+		// add the default annotations
+		annotations := map[string]string{
+			"lagoon.sh/version": buildValues.LagoonVersion,
+		}
+
+		// add any additional labels
+		if buildValues.BuildType == "branch" {
+			annotations["lagoon.sh/branch"] = buildValues.Branch
+		} else if buildValues.BuildType == "pullrequest" {
+			annotations["lagoon.sh/prNumber"] = buildValues.PRNumber
+			annotations["lagoon.sh/prHeadBranch"] = buildValues.PRHeadBranch
+			annotations["lagoon.sh/prBaseBranch"] = buildValues.PRBaseBranch
+		}
+
+		for _, netpol := range lagoonNetworkPolicies {
+			// add the default labels
+			labels := map[string]string{
+				"app.kubernetes.io/managed-by": "build-deploy-tool",
+				"app.kubernetes.io/instance":   "service-network-policy",
+				"app.kubernetes.io/name":       "service-network-policy",
+				"lagoon.sh/template":           "service-network-policy-0.1.0",
+				"lagoon.sh/project":            buildValues.Project,
+				"lagoon.sh/environment":        buildValues.Environment,
+				"lagoon.sh/environmentType":    buildValues.EnvironmentType,
+				"lagoon.sh/buildType":          buildValues.BuildType,
+				"lagoon.sh/service":            netpol.Service,
+				"lagoon.sh/service-type":       "network-policy",
+			}
+
+			// work out the policies for the specific service from the .lagoon.yml file here
+			var npirs []networkv1.NetworkPolicyIngressRule
+			for _, pp := range netpol.Projects {
+				// this generates any project specific policies
+				npirs = append(npirs, generateProjectIngressRule(pp))
+			}
+
+			for _, op := range netpol.Organizations {
+				// this generates any organization specific policies
+				npirs = append(npirs, generateOrganizationIngressRule(op))
+			}
+			np := networkv1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "NetworkPolicy",
+					APIVersion: "networking.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        netpol.Service,
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: networkv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							// set the podselector to be that of the requested service, all other policies defined in the .lagoon.yml file
+							// will get enerated above
+							"lagoon.sh/service": netpol.Service,
+						},
+					},
+					Ingress: npirs,
+				},
+			}
+			nps = append(nps, np)
+		}
+	}
+	return nps, nil
+}
+
 func TemplateNetworkPolicy(ingress *networkv1.NetworkPolicy) ([]byte, error) {
 	separator := []byte("---\n")
 	var templateYAML []byte
@@ -86,4 +169,100 @@ func TemplateNetworkPolicy(ingress *networkv1.NetworkPolicy) ([]byte, error) {
 	restoreResult := append(separator[:], iBytes[:]...)
 	templateYAML = append(templateYAML, restoreResult[:]...)
 	return templateYAML, nil
+}
+
+func generateProjectIngressRule(pp lagoon.ProjectNetworkPolicies) networkv1.NetworkPolicyIngressRule {
+	namespaceSelectors := []metav1.LabelSelectorRequirement{
+		{
+			Key:      "lagoon.sh/project",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{pp.Name},
+		},
+	}
+	if pp.Environment != "" {
+		environmentName := machineryns.ShortenEnvironment(pp.Name, machineryns.MakeSafe(pp.Environment))
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environment",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{environmentName},
+		})
+	}
+	if pp.EnvironmentType != "" {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environmentType",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{pp.EnvironmentType},
+		})
+	}
+	if pp.ExcludeEnvironments != nil {
+		lagoonEnvironments := []string{}
+		for _, exEnv := range pp.ExcludeEnvironments {
+			lagoonEnvironments = append(lagoonEnvironments, machineryns.ShortenEnvironment(pp.Name, machineryns.MakeSafe(exEnv.Name)))
+		}
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environment",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   lagoonEnvironments,
+		})
+	}
+	if pp.ExcludePullrequests {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/buildType",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"pullrequest"},
+		})
+	}
+
+	return networkv1.NetworkPolicyIngressRule{
+		From: []networkv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{},
+			},
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: namespaceSelectors,
+				},
+			},
+		},
+	}
+}
+
+func generateOrganizationIngressRule(op lagoon.OrgNetworkPolicies) networkv1.NetworkPolicyIngressRule {
+	namespaceSelectors := []metav1.LabelSelectorRequirement{
+		{
+			Key:      "organization.lagoon.sh/name",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{op.Name},
+		},
+	}
+	if op.EnvironmentType != "" {
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/environmentType",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{op.EnvironmentType},
+		})
+	}
+	if op.ExcludeProjects != nil {
+		lagoonProjects := []string{}
+		for _, exEnv := range op.ExcludeProjects {
+			lagoonProjects = append(lagoonProjects, machineryns.MakeSafe(exEnv.Name))
+		}
+		namespaceSelectors = append(namespaceSelectors, metav1.LabelSelectorRequirement{
+			Key:      "lagoon.sh/project",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   lagoonProjects,
+		})
+	}
+	return networkv1.NetworkPolicyIngressRule{
+		From: []networkv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{},
+			},
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: namespaceSelectors,
+				},
+			},
+		},
+	}
 }

--- a/internal/templating/template_podspec.go
+++ b/internal/templating/template_podspec.go
@@ -1,0 +1,598 @@
+package templating
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/uselagoon/build-deploy-tool/internal/generator"
+	"github.com/uselagoon/build-deploy-tool/internal/helpers"
+	"github.com/uselagoon/build-deploy-tool/internal/servicetypes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// deployments and cronjobs share mostly the same pod template spec
+// in cases where they differ, check if the cronjobCommand is provided to determine if the pod template spec is for a cronjob or not
+func generatePodTemplateSpec(
+	buildValues generator.BuildValues,
+	serviceValues generator.ServiceValues,
+	serviceTypeValues *servicetypes.ServiceType,
+	objectMeta metav1.ObjectMeta,
+	templateAnnotations map[string]string,
+	name, cronjobCommand string,
+) (*corev1.PodTemplateSpec, error) {
+	var podTemplateSpec corev1.PodTemplateSpec
+	additionalLabels := make(map[string]string)
+
+	tpld := struct {
+		ServiceValues     interface{}
+		ServiceTypeValues interface{}
+	}{
+		serviceValues,
+		serviceTypeValues,
+	}
+
+	podTemplateSpec.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
+	if cronjobCommand != "" {
+		if serviceValues.CronjobUseSpotInstances {
+			// handle spot instance label and affinity/tolerations/selectors
+			additionalLabels["lagoon.sh/spot"] = "true"
+			podTemplateSpec.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: 1,
+							Preference: corev1.NodeSelectorTerm{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "lagoon.sh/spot",
+										Operator: corev1.NodeSelectorOpExists,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			podTemplateSpec.Spec.Tolerations = []corev1.Toleration{
+				{
+					Key:      "lagoon.sh/spot",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "lagoon.sh/spot",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			}
+			if serviceValues.CronjobForceSpotInstances {
+				podTemplateSpec.Spec.NodeSelector = map[string]string{
+					"lagoon.sh/spot": "true",
+				}
+			}
+		}
+	} else {
+		if serviceValues.UseSpotInstances {
+			// handle spot instance label and affinity/tolerations/selectors
+			additionalLabels["lagoon.sh/spot"] = "true"
+			podTemplateSpec.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: 1,
+							Preference: corev1.NodeSelectorTerm{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "lagoon.sh/spot",
+										Operator: corev1.NodeSelectorOpExists,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			podTemplateSpec.Spec.Tolerations = []corev1.Toleration{
+				{
+					Key:      "lagoon.sh/spot",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "lagoon.sh/spot",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectPreferNoSchedule,
+				},
+			}
+			if serviceValues.ForceSpotInstances {
+				podTemplateSpec.Spec.NodeSelector = map[string]string{
+					"lagoon.sh/spot": "true",
+				}
+			}
+		}
+	}
+	// start cronjob template
+	podTemplateSpec.ObjectMeta = metav1.ObjectMeta{
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+	for key, value := range objectMeta.Labels {
+		podTemplateSpec.ObjectMeta.Labels[key] = value
+	}
+	// add any additional annotations
+	for key, value := range objectMeta.Annotations {
+		podTemplateSpec.ObjectMeta.Annotations[key] = value
+	}
+	for key, value := range templateAnnotations {
+		podTemplateSpec.ObjectMeta.Annotations[key] = value
+	}
+
+	// disable service links, this prevents some environment variables that confuse lagoon services being
+	// added to the containers
+	podTemplateSpec.Spec.EnableServiceLinks = helpers.BoolPtr(false)
+	if serviceTypeValues.EnableServiceLinks {
+		podTemplateSpec.Spec.EnableServiceLinks = helpers.BoolPtr(true)
+	}
+	// set the priority class
+	podTemplateSpec.Spec.PriorityClassName = fmt.Sprintf("lagoon-priority-%s", buildValues.EnvironmentType)
+
+	// handle the podescurity from rootless workloads
+	if buildValues.PodSecurityContext.RunAsUser != 0 {
+		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser:  helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsUser),
+			RunAsGroup: helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsGroup),
+			FSGroup:    helpers.Int64Ptr(buildValues.PodSecurityContext.FsGroup),
+		}
+	}
+	// some services have a fsgroup override
+	if serviceTypeValues.PodSecurityContext.HasDefault {
+		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
+			FSGroup: helpers.Int64Ptr(serviceTypeValues.PodSecurityContext.FSGroup),
+		}
+	}
+	if buildValues.PodSecurityContext.OnRootMismatch {
+		fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+		if podTemplateSpec.Spec.SecurityContext != nil {
+			podTemplateSpec.Spec.SecurityContext.FSGroupChangePolicy = &fsGroupChangePolicy
+		} else {
+			podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
+				FSGroupChangePolicy: &fsGroupChangePolicy,
+			}
+		}
+	}
+	// start set up any volumes this cronjob can use
+	// first handle any dynamic secret volumes that come from kubernetes secrets that are labeled
+	for _, dsv := range buildValues.DynamicSecretVolumes {
+		volume := corev1.Volume{
+			Name: dsv.Name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: dsv.Secret.SecretName,
+					Optional:   &dsv.Secret.Optional,
+				},
+			},
+		}
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+
+	// add any additional volumes with volumes
+	for _, av := range serviceValues.AdditionalVolumes {
+		volume := corev1.Volume{
+			Name: av.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: av.Name,
+				},
+			},
+		}
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+
+	// if there is a persistent volume attached to this service, handle adding that here
+	if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
+		volume := corev1.Volume{
+			Name: serviceValues.PersistentVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: serviceValues.PersistentVolumeName,
+				},
+			},
+		}
+		// if this servicetype has defaults, use them if one is not provided
+		if serviceValues.PersistentVolumePath == "" {
+			volume.Name = serviceValues.OverrideName
+			volume.VolumeSource.PersistentVolumeClaim.ClaimName = serviceValues.OverrideName
+		}
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+
+	// if there are any specific container volume overrides provided, handle those here
+	for _, pcv := range serviceTypeValues.PrimaryContainer.Volumes {
+		volume := corev1.Volume{}
+		helpers.TemplateThings(tpld, pcv, &volume)
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+	for _, scv := range serviceTypeValues.SecondaryContainer.Volumes {
+		volume := corev1.Volume{}
+		helpers.TemplateThings(tpld, scv, &volume)
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+	// end set up any volumes this cronjob can use
+
+	// handle any image pull secrets, add the default one first
+	pullsecrets := []corev1.LocalObjectReference{
+		{
+			Name: generator.DefaultImagePullSecret,
+		},
+	}
+	// then consume any from the custom provided container registries
+	for _, pullsecret := range buildValues.ContainerRegistry {
+		pullsecrets = append(pullsecrets, corev1.LocalObjectReference{
+			Name: pullsecret.SecretName,
+		})
+	}
+	podTemplateSpec.Spec.ImagePullSecrets = pullsecrets
+
+	// start working out the containers to add
+	// add any init container that the service may have
+	if serviceTypeValues.InitContainer.Name != "" {
+		enableInit := false
+		init := serviceTypeValues.InitContainer
+		// check if the init container has any flags required to add it
+		for k, v := range buildValues.FeatureFlags {
+			if init.FeatureFlags[k] == v {
+				enableInit = true
+			}
+		}
+		// otherwise if there are no flags
+		if enableInit || init.FeatureFlags == nil {
+			for _, svm := range serviceTypeValues.InitContainer.VolumeMounts {
+				volumeMount := corev1.VolumeMount{}
+				helpers.TemplateThings(tpld, svm, &volumeMount)
+				init.Container.VolumeMounts = append(init.Container.VolumeMounts, volumeMount)
+			}
+			cmd := []string{}
+			for _, c := range init.Command {
+				var c2 string
+				helpers.TemplateThings(tpld, c, &c2)
+				cmd = append(cmd, c2)
+			}
+			init.Container.Command = cmd
+			// init containers will more than likely contain public images, we should add a provided pull through imagecache if one is defined
+			if buildValues.ImageCache != "" {
+				init.Container.Image = fmt.Sprintf("%s%s", buildValues.ImageCache, init.Container.Image)
+			}
+			podTemplateSpec.Spec.InitContainers = append(podTemplateSpec.Spec.InitContainers, init.Container)
+		}
+	}
+
+	// handle the primary container for the service type
+	container := serviceTypeValues.PrimaryContainer
+
+	// handle setting the rest of the containers specs with values from the service or build values
+	container.Container.Name = name
+	if val, ok := buildValues.ImageReferences[serviceValues.Name]; ok {
+		container.Container.Image = val
+	} else {
+		return nil, fmt.Errorf("no image reference was found for primary container of service %s", serviceValues.Name)
+	}
+
+	// set up cronjobs if required
+	cronjobs := ""
+	for _, cronjob := range serviceValues.InPodCronjobs {
+		cronjobs = fmt.Sprintf("%s%s %s\n", cronjobs, cronjob.Schedule, cronjob.Command)
+	}
+	container.Container.Env = append(container.Container.Env, container.EnvVars...)
+	envvars := []corev1.EnvVar{}
+	envvars = append(envvars, corev1.EnvVar{
+		Name:  "LAGOON_GIT_SHA",
+		Value: buildValues.GitSHA,
+	})
+	if cronjobCommand == "" {
+		envvars = append(envvars, corev1.EnvVar{
+			Name:  "CRONJOBS",
+			Value: cronjobs,
+		})
+	}
+	envvars = append(envvars, corev1.EnvVar{
+		Name:  "SERVICE_NAME",
+		Value: serviceValues.OverrideName,
+	})
+	container.Container.Env = append(container.Container.Env, envvars...)
+	container.Container.EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "lagoon-platform-env",
+				},
+			},
+		}, {
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "lagoon-env",
+				},
+			},
+		},
+	}
+	for _, dds := range buildValues.DynamicDBaaSSecrets {
+		container.Container.EnvFrom = append(container.Container.EnvFrom, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: dds,
+				},
+			},
+		})
+	}
+
+	// mount the volumes in the primary container
+	for _, dsm := range buildValues.DynamicSecretMounts {
+		volumeMount := corev1.VolumeMount{
+			Name:      dsm.Name,
+			MountPath: dsm.MountPath,
+			ReadOnly:  dsm.ReadOnly,
+		}
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
+	}
+	// add any additional volumes with volumemounts
+	for _, avm := range serviceValues.AdditionalVolumes {
+		volumeMount := corev1.VolumeMount{
+			Name:      avm.Name,
+			MountPath: avm.Path,
+		}
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
+	}
+	if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
+		volumeMount := corev1.VolumeMount{
+			Name:      serviceValues.PersistentVolumeName,
+			MountPath: serviceValues.PersistentVolumePath,
+		}
+		// if this servicetype has a default volume path, use them it if one isn't provided
+		if serviceValues.PersistentVolumePath == "" {
+			volumeMount.MountPath = serviceTypeValues.Volumes.PersistentVolumePath
+			volumeMount.Name = serviceValues.OverrideName
+		}
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
+	}
+	for _, svm := range serviceTypeValues.PrimaryContainer.VolumeMounts {
+		volumeMount := corev1.VolumeMount{}
+		helpers.TemplateThings(tpld, svm, &volumeMount)
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
+	}
+	if serviceValues.PersistentVolumeName != "" && serviceValues.PersistentVolumePath != "" && serviceTypeValues.Volumes.PersistentVolumeSize == "" {
+		container.Container.VolumeMounts = append(container.Container.VolumeMounts, corev1.VolumeMount{
+			Name:      serviceValues.PersistentVolumeName,
+			MountPath: serviceValues.PersistentVolumePath,
+		})
+		volume := corev1.Volume{
+			Name: serviceValues.PersistentVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: serviceValues.PersistentVolumeName,
+				},
+			},
+		}
+		podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, volume)
+	}
+
+	if buildValues.Resources.Limits.Memory != "" {
+		if container.Container.Resources.Limits == nil {
+			container.Container.Resources.Limits = corev1.ResourceList{}
+		}
+		container.Container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(buildValues.Resources.Limits.Memory)
+	}
+	if buildValues.Resources.Limits.EphemeralStorage != "" {
+		if container.Container.Resources.Limits == nil {
+			container.Container.Resources.Limits = corev1.ResourceList{}
+		}
+		container.Container.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Limits.EphemeralStorage)
+	}
+	if buildValues.Resources.Requests.EphemeralStorage != "" {
+		if container.Container.Resources.Requests == nil {
+			container.Container.Resources.Requests = corev1.ResourceList{}
+		}
+		container.Container.Resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Requests.EphemeralStorage)
+	}
+
+	if cronjobCommand != "" {
+		podTemplateSpec.Spec.DNSConfig = &corev1.PodDNSConfig{
+			Options: []corev1.PodDNSConfigOption{
+				{
+					Name:  "timeout",
+					Value: helpers.StrPtr("60"),
+				},
+				{
+					Name:  "attempts",
+					Value: helpers.StrPtr("10"),
+				},
+			},
+		}
+		podTemplateSpec.Spec.RestartPolicy = corev1.RestartPolicyNever
+		container.Container.Command = []string{"/lagoon/cronjob.sh", cronjobCommand}
+		// strip ports from the cronjobs
+		container.Container.Ports = nil
+		container.Container.ReadinessProbe = nil
+		container.Container.LivenessProbe = nil
+	} else {
+		if serviceValues.AdditionalServicePorts != nil {
+			// nulify the existing ports
+			container.Container.Ports = []corev1.ContainerPort{}
+			// start compose service port override templating here
+			for idx, addPort := range serviceValues.AdditionalServicePorts {
+				port := corev1.ContainerPort{
+					Name:          fmt.Sprintf("tcp-%d", addPort.ServicePort.Target),
+					ContainerPort: int32(addPort.ServicePort.Target),
+					Protocol:      corev1.Protocol(strings.ToUpper(addPort.ServicePort.Protocol)),
+				}
+				if idx == 0 {
+					// first port in the docker compose file should be a tcp based port (default unless udp or other is provided in the docker-compose file)
+					// the first port in the list will be used for any liveness/readiness probes, and will override the default option the container has
+					switch addPort.ServicePort.Protocol {
+					case "tcp":
+						container.Container.ReadinessProbe = &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										Type:   intstr.Int,
+										IntVal: int32(addPort.ServicePort.Target),
+									},
+								},
+							},
+							InitialDelaySeconds: 1, // @TODO make the timeout/delays configurable?
+							TimeoutSeconds:      1,
+						}
+						container.Container.LivenessProbe = &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{
+									Port: intstr.IntOrString{
+										Type:   intstr.Int,
+										IntVal: int32(addPort.ServicePort.Target),
+									},
+								},
+							},
+							InitialDelaySeconds: 60, // @TODO make the timeout/delays configurable?
+							TimeoutSeconds:      10,
+						}
+					default:
+						return nil, fmt.Errorf("first port defined is not a tcp port, please ensure the first port is tcp")
+					}
+				}
+				switch addPort.ServicePort.Protocol {
+				case "udp":
+					port.Name = fmt.Sprintf("udp-%d", addPort.ServicePort.Target)
+				}
+				// set the ports into the container
+				container.Container.Ports = append(container.Container.Ports, port)
+			}
+		} else {
+			// otherwise if the service has a default port, and it can be changed, handle changing it here
+			if serviceTypeValues.Ports.CanChangePort {
+				// check if the port override is defined
+				if serviceValues.ServicePort != 0 {
+					// and change the port in the container definition to suit
+					container.Container.ReadinessProbe.ProbeHandler.TCPSocket.Port.IntVal = serviceValues.ServicePort
+					container.Container.LivenessProbe.ProbeHandler.TCPSocket.Port.IntVal = serviceValues.ServicePort
+					container.Container.Ports[0].ContainerPort = serviceValues.ServicePort
+				}
+			}
+		}
+	}
+
+	// append the final defined container to the spec
+	podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, container.Container)
+
+	// if this service has a secondary container provided (mainly will be `nginx-php`, but could be others in the future)
+	if serviceValues.LinkedService == nil && serviceTypeValues.SecondaryContainer.Name != "" {
+		// if no linked service is found from the docker-compose services, drop an error
+		return nil, fmt.Errorf("service type %s has a secondary container defined, but no linked service was found", serviceValues.Type)
+	}
+	// if a linked service is provided, and the servicetype supports it, handle that here
+	if serviceValues.LinkedService != nil && serviceTypeValues.SecondaryContainer.Name != "" {
+		linkedContainer := serviceTypeValues.SecondaryContainer
+
+		// handle setting the rest of the containers specs with values from the service or build values
+		linkedContainer.Container.Name = linkedContainer.Name
+		if val, ok := buildValues.ImageReferences[serviceValues.LinkedService.Name]; ok {
+			linkedContainer.Container.Image = val
+		} else {
+			return nil, fmt.Errorf("no image reference was found for secondary container %s of service %s", serviceValues.LinkedService.Name, serviceValues.Name)
+		}
+
+		linkedContainer.Container.Env = append(linkedContainer.Container.Env, linkedContainer.EnvVars...)
+		envvars := []corev1.EnvVar{}
+		envvars = append(envvars, corev1.EnvVar{
+			Name:  "LAGOON_GIT_SHA",
+			Value: buildValues.GitSHA,
+		})
+		// if cronjobCommand == "" {
+		// 	envvars = append(envvars, corev1.EnvVar{
+		// 		Name:  "CRONJOBS",
+		// 		Value: cronjobs,
+		// 	})
+		// }
+		envvars = append(envvars, corev1.EnvVar{
+			Name:  "SERVICE_NAME",
+			Value: serviceValues.OverrideName,
+		})
+		linkedContainer.Container.Env = append(linkedContainer.Container.Env, envvars...)
+		linkedContainer.Container.EnvFrom = []corev1.EnvFromSource{
+			{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "lagoon-platform-env",
+					},
+				},
+			}, {
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "lagoon-env",
+					},
+				},
+			},
+		}
+		for _, dds := range buildValues.DynamicDBaaSSecrets {
+			linkedContainer.Container.EnvFrom = append(linkedContainer.Container.EnvFrom, corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: dds,
+					},
+				},
+			})
+		}
+		for _, dsm := range buildValues.DynamicSecretMounts {
+			volumeMount := corev1.VolumeMount{
+				Name:      dsm.Name,
+				MountPath: dsm.MountPath,
+				ReadOnly:  dsm.ReadOnly,
+			}
+			linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
+		}
+
+		// add any additional volumes with volumemounts
+		for _, avm := range serviceValues.AdditionalVolumes {
+			volumeMount := corev1.VolumeMount{
+				Name:      avm.Name,
+				MountPath: avm.Path,
+			}
+			linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
+		}
+		if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
+			volumeMount := corev1.VolumeMount{
+				Name:      serviceValues.PersistentVolumeName,
+				MountPath: serviceValues.PersistentVolumePath,
+			}
+			linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
+		}
+
+		for _, svm := range serviceTypeValues.SecondaryContainer.VolumeMounts {
+			volumeMount := corev1.VolumeMount{}
+			helpers.TemplateThings(tpld, svm, &volumeMount)
+			linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
+		}
+
+		// set the resource limit overrides if they are provided
+		if buildValues.Resources.Limits.Memory != "" {
+			if linkedContainer.Container.Resources.Limits == nil {
+				linkedContainer.Container.Resources.Limits = corev1.ResourceList{}
+			}
+			linkedContainer.Container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(buildValues.Resources.Limits.Memory)
+		}
+		if buildValues.Resources.Limits.EphemeralStorage != "" {
+			if linkedContainer.Container.Resources.Limits == nil {
+				linkedContainer.Container.Resources.Limits = corev1.ResourceList{}
+			}
+			linkedContainer.Container.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Limits.EphemeralStorage)
+		}
+		if buildValues.Resources.Requests.EphemeralStorage != "" {
+			if linkedContainer.Container.Resources.Requests == nil {
+				linkedContainer.Container.Resources.Requests = corev1.ResourceList{}
+			}
+			linkedContainer.Container.Resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Requests.EphemeralStorage)
+		}
+
+		podTemplateSpec.Spec.Containers = append(podTemplateSpec.Spec.Containers, linkedContainer.Container)
+	}
+	return &podTemplateSpec, nil
+}

--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -101,7 +101,7 @@ func GenerateCronjobTemplate(
 				}
 
 				// disable automounted service account
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
 
 				cronjob.Spec.Schedule = nCronjob.Schedule
 				cronjob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent

--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -9,8 +9,6 @@ import (
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/servicetypes"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metavalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -66,13 +64,6 @@ func GenerateCronjobTemplate(
 
 				templateAnnotations := make(map[string]string)
 				templateAnnotations["lagoon.sh/configMapSha"] = buildValues.ConfigMapSha
-				tpld := struct {
-					ServiceValues     interface{}
-					ServiceTypeValues interface{}
-				}{
-					serviceValues,
-					serviceTypeValues,
-				}
 
 				cronjob := &batchv1.CronJob{
 					TypeMeta: metav1.TypeMeta{
@@ -87,28 +78,11 @@ func GenerateCronjobTemplate(
 				}
 				cronjob.ObjectMeta.Labels = labels
 				cronjob.ObjectMeta.Annotations = annotations
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-					Options: []corev1.PodDNSConfigOption{
-						{
-							Name:  "timeout",
-							Value: helpers.StrPtr("60"),
-						},
-						{
-							Name:  "attempts",
-							Value: helpers.StrPtr("10"),
-						},
-					},
-				}
-
-				// disable automounted service account
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
-
 				cronjob.Spec.Schedule = nCronjob.Schedule
 				cronjob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
 				cronjob.Spec.SuccessfulJobsHistoryLimit = helpers.Int32Ptr(0)
 				cronjob.Spec.FailedJobsHistoryLimit = helpers.Int32Ptr(1)
 				cronjob.Spec.StartingDeadlineSeconds = helpers.Int64Ptr(240)
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 
 				// time has already been parsed in generator/services to check for errors
 				// and the default timeout is added in generator/services
@@ -119,40 +93,6 @@ func GenerateCronjobTemplate(
 				if serviceValues.CronjobUseSpotInstances {
 					// handle spot instance label and affinity/tolerations/selectors
 					additionalLabels["lagoon.sh/spot"] = "true"
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Affinity = &corev1.Affinity{
-						NodeAffinity: &corev1.NodeAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-								{
-									Weight: 1,
-									Preference: corev1.NodeSelectorTerm{
-										MatchExpressions: []corev1.NodeSelectorRequirement{
-											{
-												Key:      "lagoon.sh/spot",
-												Operator: corev1.NodeSelectorOpExists,
-											},
-										},
-									},
-								},
-							},
-						},
-					}
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-						{
-							Key:      "lagoon.sh/spot",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:      "lagoon.sh/spot",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectPreferNoSchedule,
-						},
-					}
-					if serviceValues.CronjobForceSpotInstances {
-						cronjob.Spec.JobTemplate.Spec.Template.Spec.NodeSelector = map[string]string{
-							"lagoon.sh/spot": "true",
-						}
-					}
 				}
 
 				for key, value := range additionalLabels {
@@ -179,272 +119,9 @@ func GenerateCronjobTemplate(
 				if err != nil {
 					return nil, err
 				}
-
-				// start cronjob template
-				cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-					Labels:      map[string]string{},
-					Annotations: map[string]string{},
-				}
-				for key, value := range cronjob.ObjectMeta.Labels {
-					cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta.Labels[key] = value
-				}
-				// add any additional annotations
-				for key, value := range cronjob.ObjectMeta.Annotations {
-					cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta.Annotations[key] = value
-				}
-				for key, value := range templateAnnotations {
-					cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta.Annotations[key] = value
-				}
-
-				// disable service links, this prevents some environment variables that confuse lagoon services being
-				// added to the containers
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.EnableServiceLinks = helpers.BoolPtr(false)
-				// set the priority class
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName = fmt.Sprintf("lagoon-priority-%s", buildValues.EnvironmentType)
-
-				// handle the podescurity from rootless workloads
-				if buildValues.PodSecurityContext.RunAsUser != 0 {
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-						RunAsUser:  helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsUser),
-						RunAsGroup: helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsGroup),
-						FSGroup:    helpers.Int64Ptr(buildValues.PodSecurityContext.FsGroup),
-					}
-				}
-				// some services have a fsgroup override
-				if serviceTypeValues.PodSecurityContext.HasDefault {
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-						FSGroup: helpers.Int64Ptr(serviceTypeValues.PodSecurityContext.FSGroup),
-					}
-				}
-				if buildValues.PodSecurityContext.OnRootMismatch {
-					fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
-					if cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext != nil {
-						cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy = &fsGroupChangePolicy
-					} else {
-						cronjob.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-							FSGroupChangePolicy: &fsGroupChangePolicy,
-						}
-					}
-				}
-
-				// start set up any volumes this cronjob can use
-				// first handle any dynamic secret volumes that come from kubernetes secrets that are labeled
-				for _, dsv := range buildValues.DynamicSecretVolumes {
-					volume := corev1.Volume{
-						Name: dsv.Name,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: dsv.Secret.SecretName,
-								Optional:   &dsv.Secret.Optional,
-							},
-						},
-					}
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes, volume)
-				}
-
-				// if there is a persistent volume attached to this service, handle adding that here
-				if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
-					volume := corev1.Volume{
-						Name: serviceValues.PersistentVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: serviceValues.PersistentVolumeName,
-							},
-						},
-					}
-					// if this servicetype has defaults, use them if one is not provided
-					if serviceValues.PersistentVolumePath == "" {
-						volume.Name = serviceValues.OverrideName
-						volume.VolumeSource.PersistentVolumeClaim.ClaimName = serviceValues.OverrideName
-					}
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes, volume)
-				}
-
-				// if there are any specific container volume overrides provided, handle those here
-				for _, pcv := range serviceTypeValues.PrimaryContainer.Volumes {
-					volume := corev1.Volume{}
-					helpers.TemplateThings(tpld, pcv, &volume)
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes, volume)
-				}
-				for _, scv := range serviceTypeValues.SecondaryContainer.Volumes {
-					volume := corev1.Volume{}
-					helpers.TemplateThings(tpld, scv, &volume)
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes, volume)
-				}
-
-				// future handle any additional volume mounts here
-				// @TODO
-
-				// end set up any volumes this cronjob can use
-
-				// handle any image pull secrets, add the default one first
-				pullsecrets := []corev1.LocalObjectReference{
-					{
-						Name: generator.DefaultImagePullSecret,
-					},
-				}
-				// then consume any from the custom provided container registries
-				for _, pullsecret := range buildValues.ContainerRegistry {
-					pullsecrets = append(pullsecrets, corev1.LocalObjectReference{
-						Name: pullsecret.SecretName,
-					})
-				}
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = pullsecrets
-
-				// start working out the containers to add
-				// add any init container that the service may have
-				if serviceTypeValues.InitContainer.Name != "" {
-					enableInit := false
-					init := serviceTypeValues.InitContainer
-					// check if the init container has any flags required to add it
-					for k, v := range buildValues.FeatureFlags {
-						if init.FeatureFlags[k] == v {
-							enableInit = true
-						}
-					}
-					// otherwise if there are no flags
-					if enableInit || init.FeatureFlags == nil {
-						for _, svm := range serviceTypeValues.InitContainer.VolumeMounts {
-							volumeMount := corev1.VolumeMount{}
-							helpers.TemplateThings(tpld, svm, &volumeMount)
-							init.Container.VolumeMounts = append(init.Container.VolumeMounts, volumeMount)
-						}
-						cmd := []string{}
-						for _, c := range init.Command {
-							var c2 string
-							helpers.TemplateThings(tpld, c, &c2)
-							cmd = append(cmd, c2)
-						}
-						init.Container.Command = cmd
-						cronjob.Spec.JobTemplate.Spec.Template.Spec.InitContainers = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.InitContainers, init.Container)
-					}
-				}
-
-				// handle the primary container for the service type
-				container := serviceTypeValues.PrimaryContainer
-
-				// handle setting the rest of the containers specs with values from the service or build values
-				container.Container.Name = nCronjob.Name
-				if val, ok := buildValues.ImageReferences[serviceValues.Name]; ok {
-					container.Container.Image = val
-				} else {
-					return nil, fmt.Errorf("no image reference was found for primary container of service %s", serviceValues.Name)
-				}
-
-				// set up cronjobs if required
-				cronjobs := ""
-				for _, cronjob := range serviceValues.InPodCronjobs {
-					cronjobs = fmt.Sprintf("%s%s %s\n", cronjobs, cronjob.Schedule, cronjob.Command)
-				}
-				container.Container.Env = append(container.Container.Env, container.EnvVars...)
-				envvars := []corev1.EnvVar{
-					{
-						Name:  "LAGOON_GIT_SHA",
-						Value: buildValues.GitSHA,
-					},
-					{
-						Name:  "SERVICE_NAME",
-						Value: serviceValues.OverrideName,
-					},
-				}
-				container.Container.Env = append(container.Container.Env, envvars...)
-				container.Container.EnvFrom = []corev1.EnvFromSource{
-					{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "lagoon-platform-env",
-							},
-						},
-					}, {
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "lagoon-env",
-							},
-						},
-					},
-				}
-				for _, dds := range buildValues.DynamicDBaaSSecrets {
-					container.Container.EnvFrom = append(container.Container.EnvFrom, corev1.EnvFromSource{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: dds,
-							},
-						},
-					})
-				}
-
-				// mount the volumes in the primary container
-				for _, dsm := range buildValues.DynamicSecretMounts {
-					volumeMount := corev1.VolumeMount{
-						Name:      dsm.Name,
-						MountPath: dsm.MountPath,
-						ReadOnly:  dsm.ReadOnly,
-					}
-					container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-				}
-				if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
-					volumeMount := corev1.VolumeMount{
-						Name:      serviceValues.PersistentVolumeName,
-						MountPath: serviceValues.PersistentVolumePath,
-					}
-					// if this servicetype has a default volume path, use them it if one isn't provided
-					if serviceValues.PersistentVolumePath == "" {
-						volumeMount.MountPath = serviceTypeValues.Volumes.PersistentVolumePath
-						volumeMount.Name = serviceValues.OverrideName
-					}
-					container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-				}
-				for _, svm := range serviceTypeValues.PrimaryContainer.VolumeMounts {
-					volumeMount := corev1.VolumeMount{}
-					helpers.TemplateThings(tpld, svm, &volumeMount)
-					container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-				}
-				if serviceValues.PersistentVolumeName != "" && serviceValues.PersistentVolumePath != "" && serviceTypeValues.Volumes.PersistentVolumeSize == "" {
-					container.Container.VolumeMounts = append(container.Container.VolumeMounts, corev1.VolumeMount{
-						Name:      serviceValues.PersistentVolumeName,
-						MountPath: serviceValues.PersistentVolumePath,
-					})
-					volume := corev1.Volume{
-						Name: serviceValues.PersistentVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: serviceValues.PersistentVolumeName,
-							},
-						},
-					}
-					cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Volumes, volume)
-				}
-
-				if buildValues.Resources.Limits.Memory != "" {
-					if container.Container.Resources.Limits == nil {
-						container.Container.Resources.Limits = corev1.ResourceList{}
-					}
-					container.Container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(buildValues.Resources.Limits.Memory)
-				}
-				if buildValues.Resources.Limits.EphemeralStorage != "" {
-					if container.Container.Resources.Limits == nil {
-						container.Container.Resources.Limits = corev1.ResourceList{}
-					}
-					container.Container.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Limits.EphemeralStorage)
-				}
-				if buildValues.Resources.Requests.EphemeralStorage != "" {
-					if container.Container.Resources.Requests == nil {
-						container.Container.Resources.Requests = corev1.ResourceList{}
-					}
-					container.Container.Resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Requests.EphemeralStorage)
-				}
-
-				// strip ports from the cronjobs
-				container.Container.Ports = nil
-				container.Container.ReadinessProbe = nil
-				container.Container.LivenessProbe = nil
-
-				container.Container.Command = []string{"/lagoon/cronjob.sh", nCronjob.Command}
-
-				// append the final defined container to the spec
-				cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers = append(cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers, container.Container)
-
+				podTemplateSpec, _ := generatePodTemplateSpec(buildValues, serviceValues, serviceTypeValues, cronjob.ObjectMeta, templateAnnotations, nCronjob.Name, nCronjob.Command)
 				// end cronjob template
+				cronjob.Spec.JobTemplate.Spec.Template = *podTemplateSpec
 				result = append(result, *cronjob)
 			}
 		}

--- a/internal/templating/templates_cronjob.go
+++ b/internal/templating/templates_cronjob.go
@@ -27,7 +27,7 @@ func GenerateCronjobTemplate(
 	// for all the services that the build values generated
 	// iterate over them and generate any kubernetes cronjobs
 	for _, serviceValues := range checkedServices {
-		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok {
+		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok && serviceValues.Type != "external" {
 			for _, nCronjob := range serviceValues.NativeCronjobs {
 				serviceTypeValues := &servicetypes.ServiceType{}
 				helpers.DeepCopy(val, serviceTypeValues)

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -2,19 +2,15 @@ package templating
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/uselagoon/build-deploy-tool/internal/generator"
 	"github.com/uselagoon/build-deploy-tool/internal/helpers"
 	"github.com/uselagoon/build-deploy-tool/internal/servicetypes"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metavalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -101,47 +97,52 @@ func GenerateDeploymentTemplate(
 			deployment.ObjectMeta.Labels = labels
 			deployment.ObjectMeta.Annotations = annotations
 
-			// disable automounted service account
-			deployment.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
-
 			if serviceValues.UseSpotInstances {
 				// handle spot instance label and affinity/tolerations/selectors
 				additionalLabels["lagoon.sh/spot"] = "true"
-				deployment.Spec.Template.Spec.Affinity = &corev1.Affinity{
-					NodeAffinity: &corev1.NodeAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-							{
-								Weight: 1,
-								Preference: corev1.NodeSelectorTerm{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										{
-											Key:      "lagoon.sh/spot",
-											Operator: corev1.NodeSelectorOpExists,
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-				deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{
-					{
-						Key:      "lagoon.sh/spot",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoSchedule,
-					},
-					{
-						Key:      "lagoon.sh/spot",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectPreferNoSchedule,
-					},
-				}
-				if serviceValues.ForceSpotInstances {
-					deployment.Spec.Template.Spec.NodeSelector = map[string]string{
-						"lagoon.sh/spot": "true",
-					}
+			}
+
+			for key, value := range additionalLabels {
+				deployment.ObjectMeta.Labels[key] = value
+			}
+			// add any additional annotations
+			for key, value := range additionalAnnotations {
+				deployment.ObjectMeta.Annotations[key] = value
+			}
+			// validate any annotations
+			if err := apivalidation.ValidateAnnotations(deployment.ObjectMeta.Annotations, nil); err != nil {
+				if len(err) != 0 {
+					return nil, fmt.Errorf("the annotations for %s are not valid: %v", serviceValues.OverrideName, err)
 				}
 			}
+			// validate any labels
+			if err := metavalidation.ValidateLabels(deployment.ObjectMeta.Labels, nil); err != nil {
+				if len(err) != 0 {
+					return nil, fmt.Errorf("the labels for %s are not valid: %v", serviceValues.OverrideName, err)
+				}
+			}
+			// check length of labels
+			err := helpers.CheckLabelLength(deployment.ObjectMeta.Labels)
+			if err != nil {
+				return nil, err
+			}
+
+			// start deployment template
+			deployment.Spec.Replicas = helpers.Int32Ptr(1)
+			if serviceValues.Replicas != 0 {
+				deployment.Spec.Replicas = helpers.Int32Ptr(serviceValues.Replicas)
+			}
+			deployment.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name":     serviceTypeValues.Name,
+					"app.kubernetes.io/instance": serviceValues.OverrideName,
+				},
+			}
+			deployment.Spec.Strategy = serviceTypeValues.Strategy
+
+			podTemplateSpec, _ := generatePodTemplateSpec(buildValues, serviceValues, serviceTypeValues, deployment.ObjectMeta, templateAnnotations, serviceTypeValues.PrimaryContainer.Name, "")
+			// end cronjob template
+			deployment.Spec.Template = *podTemplateSpec
 			if buildValues.PodSpreadConstraints {
 				deployment.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 					{
@@ -182,513 +183,6 @@ func GenerateDeploymentTemplate(
 						},
 					},
 				}
-			}
-
-			for key, value := range additionalLabels {
-				deployment.ObjectMeta.Labels[key] = value
-			}
-			// add any additional annotations
-			for key, value := range additionalAnnotations {
-				deployment.ObjectMeta.Annotations[key] = value
-			}
-			// validate any annotations
-			if err := apivalidation.ValidateAnnotations(deployment.ObjectMeta.Annotations, nil); err != nil {
-				if len(err) != 0 {
-					return nil, fmt.Errorf("the annotations for %s are not valid: %v", serviceValues.OverrideName, err)
-				}
-			}
-			// validate any labels
-			if err := metavalidation.ValidateLabels(deployment.ObjectMeta.Labels, nil); err != nil {
-				if len(err) != 0 {
-					return nil, fmt.Errorf("the labels for %s are not valid: %v", serviceValues.OverrideName, err)
-				}
-			}
-			// check length of labels
-			err := helpers.CheckLabelLength(deployment.ObjectMeta.Labels)
-			if err != nil {
-				return nil, err
-			}
-
-			// start deployment template
-			deployment.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			}
-			for key, value := range deployment.ObjectMeta.Labels {
-				deployment.Spec.Template.ObjectMeta.Labels[key] = value
-			}
-			// add any additional annotations
-			for key, value := range deployment.ObjectMeta.Annotations {
-				deployment.Spec.Template.ObjectMeta.Annotations[key] = value
-			}
-			for key, value := range templateAnnotations {
-				deployment.Spec.Template.ObjectMeta.Annotations[key] = value
-			}
-			deployment.Spec.Replicas = helpers.Int32Ptr(1)
-			if serviceValues.Replicas != 0 {
-				deployment.Spec.Replicas = helpers.Int32Ptr(serviceValues.Replicas)
-			}
-			deployment.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app.kubernetes.io/name":     serviceTypeValues.Name,
-					"app.kubernetes.io/instance": serviceValues.OverrideName,
-				},
-			}
-			deployment.Spec.Strategy = serviceTypeValues.Strategy
-
-			// disable service links, this prevents some environment variables that confuse lagoon services being
-			// added to the containers
-			deployment.Spec.Template.Spec.EnableServiceLinks = helpers.BoolPtr(false)
-			if serviceTypeValues.EnableServiceLinks {
-				deployment.Spec.Template.Spec.EnableServiceLinks = helpers.BoolPtr(true)
-			}
-			// set the priority class
-			deployment.Spec.Template.Spec.PriorityClassName = fmt.Sprintf("lagoon-priority-%s", buildValues.EnvironmentType)
-
-			// handle the podescurity from rootless workloads
-			if buildValues.PodSecurityContext.RunAsUser != 0 {
-				deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-					RunAsUser:  helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsUser),
-					RunAsGroup: helpers.Int64Ptr(buildValues.PodSecurityContext.RunAsGroup),
-					FSGroup:    helpers.Int64Ptr(buildValues.PodSecurityContext.FsGroup),
-				}
-			}
-			// some services have a fsgroup override
-			if serviceTypeValues.PodSecurityContext.HasDefault {
-				deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-					FSGroup: helpers.Int64Ptr(serviceTypeValues.PodSecurityContext.FSGroup),
-				}
-			}
-			if buildValues.PodSecurityContext.OnRootMismatch {
-				fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
-				if deployment.Spec.Template.Spec.SecurityContext != nil {
-					deployment.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy = &fsGroupChangePolicy
-				} else {
-					deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-						FSGroupChangePolicy: &fsGroupChangePolicy,
-					}
-				}
-			}
-
-			// start set up any volumes this deployment can use
-			// first handle any dynamic secret volumes that come from kubernetes secrets that are labeled
-			for _, dsv := range buildValues.DynamicSecretVolumes {
-				volume := corev1.Volume{
-					Name: dsv.Name,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName: dsv.Secret.SecretName,
-							Optional:   &dsv.Secret.Optional,
-						},
-					},
-				}
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-
-			// add any additional volumes with volumes
-			for _, av := range serviceValues.AdditionalVolumes {
-				volume := corev1.Volume{
-					Name: av.Name,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: av.Name,
-						},
-					},
-				}
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-
-			// if there is a persistent volume attached to this service, and no additional volumes, handle adding that here
-			if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
-				volume := corev1.Volume{
-					Name: serviceValues.PersistentVolumeName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: serviceValues.PersistentVolumeName,
-						},
-					},
-				}
-				// if this servicetype has defaults, use them if one is not provided
-				if serviceValues.PersistentVolumePath == "" {
-					volume.Name = serviceValues.OverrideName
-					volume.VolumeSource.PersistentVolumeClaim.ClaimName = serviceValues.OverrideName
-				}
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-
-			// if there are any specific container volume overrides provided, handle those here
-			for _, pcv := range serviceTypeValues.PrimaryContainer.Volumes {
-				volume := corev1.Volume{}
-				helpers.TemplateThings(tpld, pcv, &volume)
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-			for _, scv := range serviceTypeValues.SecondaryContainer.Volumes {
-				volume := corev1.Volume{}
-				helpers.TemplateThings(tpld, scv, &volume)
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-
-			// future handle any additional volume mounts here
-			// @TODO
-
-			// end set up any volumes this deployment can use
-
-			// handle any image pull secrets, add the default one first
-			pullsecrets := []corev1.LocalObjectReference{
-				{
-					Name: generator.DefaultImagePullSecret,
-				},
-			}
-			// then consume any from the custom provided container registries
-			sort.Slice(buildValues.ContainerRegistry, func(i, j int) bool {
-				return buildValues.ContainerRegistry[i].Name < buildValues.ContainerRegistry[j].Name
-			})
-			for _, pullsecret := range buildValues.ContainerRegistry {
-				pullsecrets = append(pullsecrets, corev1.LocalObjectReference{
-					Name: pullsecret.SecretName,
-				})
-			}
-			deployment.Spec.Template.Spec.ImagePullSecrets = pullsecrets
-
-			// start working out the containers to add
-			// add any init container that the service may have
-			if serviceTypeValues.InitContainer.Name != "" {
-				enableInit := false
-				init := serviceTypeValues.InitContainer
-				// check if the init container has any flags required to add it
-				for k, v := range buildValues.FeatureFlags {
-					if init.FeatureFlags[k] == v {
-						enableInit = true
-					}
-				}
-				// otherwise if there are no flags
-				if enableInit || init.FeatureFlags == nil {
-					// add any volume mounts to the init container as required
-					for _, svm := range serviceTypeValues.InitContainer.VolumeMounts {
-						volumeMount := corev1.VolumeMount{}
-						helpers.TemplateThings(tpld, svm, &volumeMount)
-						init.Container.VolumeMounts = append(init.Container.VolumeMounts, volumeMount)
-					}
-					cmd := []string{}
-					for _, c := range init.Command {
-						var c2 string
-						helpers.TemplateThings(tpld, c, &c2)
-						cmd = append(cmd, c2)
-					}
-					init.Container.Command = cmd
-					// init containers will more than likely contain public images, we should add a provided pull through imagecache if one is defined
-					if buildValues.ImageCache != "" {
-						init.Container.Image = fmt.Sprintf("%s%s", buildValues.ImageCache, init.Container.Image)
-					}
-					deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, init.Container)
-				}
-			}
-
-			// handle the primary container for the service type
-			container := serviceTypeValues.PrimaryContainer
-			// if the service is set to consume the additional service ports from the docker-compose file (lagoon.sh/usecomposeports label on service)
-			// then generate those additional service ports in the deploymeny here
-			if serviceValues.AdditionalServicePorts != nil {
-				// nulify the existing ports
-				container.Container.Ports = []corev1.ContainerPort{}
-				// start compose service port override templating here
-				for idx, addPort := range serviceValues.AdditionalServicePorts {
-					port := corev1.ContainerPort{
-						Name:          fmt.Sprintf("tcp-%d", addPort.ServicePort.Target),
-						ContainerPort: int32(addPort.ServicePort.Target),
-						Protocol:      corev1.Protocol(strings.ToUpper(addPort.ServicePort.Protocol)),
-					}
-					if idx == 0 {
-						// first port in the docker compose file should be a tcp based port (default unless udp or other is provided in the docker-compose file)
-						// the first port in the list will be used for any liveness/readiness probes, and will override the default option the container has
-						switch addPort.ServicePort.Protocol {
-						case "tcp":
-							container.Container.ReadinessProbe = &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.IntOrString{
-											Type:   intstr.Int,
-											IntVal: int32(addPort.ServicePort.Target),
-										},
-									},
-								},
-								InitialDelaySeconds: 1, // @TODO make the timeout/delays configurable?
-								TimeoutSeconds:      1,
-							}
-							container.Container.LivenessProbe = &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.IntOrString{
-											Type:   intstr.Int,
-											IntVal: int32(addPort.ServicePort.Target),
-										},
-									},
-								},
-								InitialDelaySeconds: 60, // @TODO make the timeout/delays configurable?
-								TimeoutSeconds:      10,
-							}
-						default:
-							return nil, fmt.Errorf("first port defined is not a tcp port, please ensure the first port is tcp")
-						}
-					}
-					switch addPort.ServicePort.Protocol {
-					case "udp":
-						port.Name = fmt.Sprintf("udp-%d", addPort.ServicePort.Target)
-					}
-					// set the ports into the container
-					container.Container.Ports = append(container.Container.Ports, port)
-				}
-			} else {
-				// otherwise if the service has a default port, and it can be changed, handle changing it here
-				if serviceTypeValues.Ports.CanChangePort {
-					// check if the port override is defined
-					if serviceValues.ServicePort != 0 {
-						// and change the port in the container definition to suit
-						container.Container.ReadinessProbe.ProbeHandler.TCPSocket.Port.IntVal = serviceValues.ServicePort
-						container.Container.LivenessProbe.ProbeHandler.TCPSocket.Port.IntVal = serviceValues.ServicePort
-						container.Container.Ports[0].ContainerPort = serviceValues.ServicePort
-					}
-				}
-			}
-
-			// handle setting the rest of the containers specs with values from the service or build values
-			container.Container.Name = container.Name
-			if val, ok := buildValues.ImageReferences[serviceValues.Name]; ok {
-				container.Container.Image = val
-			} else {
-				return nil, fmt.Errorf("no image reference was found for primary container of service %s", serviceValues.Name)
-			}
-			// set up cronjobs if required
-			cronjobs := ""
-			for _, cronjob := range serviceValues.InPodCronjobs {
-				cronjobs = fmt.Sprintf("%s%s %s\n", cronjobs, cronjob.Schedule, cronjob.Command)
-			}
-			// add any variables from the servicetype container overrides here
-			container.Container.Env = append(container.Container.Env, container.EnvVars...)
-			envvars := []corev1.EnvVar{
-				{
-					Name:  "LAGOON_GIT_SHA",
-					Value: buildValues.GitSHA,
-				},
-				{
-					Name:  "CRONJOBS",
-					Value: cronjobs,
-				},
-				{
-					Name:  "SERVICE_NAME",
-					Value: serviceValues.OverrideName,
-				},
-			}
-			// expose any container envvars as required here
-			container.Container.Env = append(container.Container.Env, envvars...)
-			// consume the lagoon-env configmap here
-			container.Container.EnvFrom = []corev1.EnvFromSource{
-				{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "lagoon-platform-env",
-						},
-					},
-				}, {
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "lagoon-env",
-						},
-					},
-				},
-			}
-			for _, dds := range buildValues.DynamicDBaaSSecrets {
-				container.Container.EnvFrom = append(container.Container.EnvFrom, corev1.EnvFromSource{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: dds,
-						},
-					},
-				})
-			}
-
-			// mount the volumes in the primary container
-			for _, dsm := range buildValues.DynamicSecretMounts {
-				volumeMount := corev1.VolumeMount{
-					Name:      dsm.Name,
-					MountPath: dsm.MountPath,
-					ReadOnly:  dsm.ReadOnly,
-				}
-				container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-			}
-
-			// add any additional volumes with volumemounts
-			for _, avm := range serviceValues.AdditionalVolumes {
-				volumeMount := corev1.VolumeMount{
-					Name:      avm.Name,
-					MountPath: avm.Path,
-				}
-				container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-			}
-			// handle the default storage volumemount
-			if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
-				volumeMount := corev1.VolumeMount{
-					Name:      serviceValues.PersistentVolumeName,
-					MountPath: serviceValues.PersistentVolumePath,
-				}
-				// if this servicetype has a default volume path, use them it if one isn't provided
-				if serviceValues.PersistentVolumePath == "" {
-					volumeMount.MountPath = serviceTypeValues.Volumes.PersistentVolumePath
-					volumeMount.Name = serviceValues.OverrideName
-				}
-				container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-			}
-			// create the container volume mounts
-			for _, svm := range serviceTypeValues.PrimaryContainer.VolumeMounts {
-				volumeMount := corev1.VolumeMount{}
-				helpers.TemplateThings(tpld, svm, &volumeMount)
-				container.Container.VolumeMounts = append(container.Container.VolumeMounts, volumeMount)
-			}
-			// mount the default storage volume if one exists
-			if serviceValues.PersistentVolumeName != "" && serviceValues.PersistentVolumePath != "" && serviceTypeValues.Volumes.PersistentVolumeSize == "" {
-				container.Container.VolumeMounts = append(container.Container.VolumeMounts, corev1.VolumeMount{
-					Name:      serviceValues.PersistentVolumeName,
-					MountPath: serviceValues.PersistentVolumePath,
-				})
-				volume := corev1.Volume{
-					Name: serviceValues.PersistentVolumeName,
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: serviceValues.PersistentVolumeName,
-						},
-					},
-				}
-				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volume)
-			}
-
-			// set the resource limit overrides if they are provided
-			if buildValues.Resources.Limits.Memory != "" {
-				if container.Container.Resources.Limits == nil {
-					container.Container.Resources.Limits = corev1.ResourceList{}
-				}
-				container.Container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(buildValues.Resources.Limits.Memory)
-			}
-			if buildValues.Resources.Limits.EphemeralStorage != "" {
-				if container.Container.Resources.Limits == nil {
-					container.Container.Resources.Limits = corev1.ResourceList{}
-				}
-				container.Container.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Limits.EphemeralStorage)
-			}
-			if buildValues.Resources.Requests.EphemeralStorage != "" {
-				if container.Container.Resources.Requests == nil {
-					container.Container.Resources.Requests = corev1.ResourceList{}
-				}
-				container.Container.Resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Requests.EphemeralStorage)
-			}
-
-			// append the final defined container to the spec
-			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, container.Container)
-
-			// if this service has a secondary container provided (mainly will be `nginx-php`, but could be others in the future)
-			if serviceValues.LinkedService == nil && serviceTypeValues.SecondaryContainer.Name != "" {
-				// if no linked service is found from the docker-compose services, drop an error
-				return nil, fmt.Errorf("service type %s has a secondary container defined, but no linked service was found", serviceValues.Type)
-			}
-			// if a linked service is provided, and the servicetype supports it, handle that here
-			if serviceValues.LinkedService != nil && serviceTypeValues.SecondaryContainer.Name != "" {
-				linkedContainer := serviceTypeValues.SecondaryContainer
-
-				// handle setting the rest of the containers specs with values from the service or build values
-				linkedContainer.Container.Name = linkedContainer.Name
-				if val, ok := buildValues.ImageReferences[serviceValues.LinkedService.Name]; ok {
-					linkedContainer.Container.Image = val
-				} else {
-					return nil, fmt.Errorf("no image reference was found for secondary container %s of service %s", serviceValues.LinkedService.Name, serviceValues.Name)
-				}
-
-				linkedContainer.Container.Env = append(linkedContainer.Container.Env, linkedContainer.EnvVars...)
-				envvars := []corev1.EnvVar{
-					{
-						Name:  "LAGOON_GIT_SHA",
-						Value: buildValues.GitSHA,
-					},
-					{
-						Name:  "SERVICE_NAME",
-						Value: serviceValues.OverrideName,
-					},
-				}
-				linkedContainer.Container.Env = append(linkedContainer.Container.Env, envvars...)
-				linkedContainer.Container.EnvFrom = []corev1.EnvFromSource{
-					{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "lagoon-platform-env",
-							},
-						},
-					}, {
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "lagoon-env",
-							},
-						},
-					},
-				}
-				for _, dds := range buildValues.DynamicDBaaSSecrets {
-					linkedContainer.Container.EnvFrom = append(linkedContainer.Container.EnvFrom, corev1.EnvFromSource{
-						SecretRef: &corev1.SecretEnvSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: dds,
-							},
-						},
-					})
-				}
-				for _, dsm := range buildValues.DynamicSecretMounts {
-					volumeMount := corev1.VolumeMount{
-						Name:      dsm.Name,
-						MountPath: dsm.MountPath,
-						ReadOnly:  dsm.ReadOnly,
-					}
-					linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
-				}
-
-				// add any additional volumes with volumemounts
-				for _, avm := range serviceValues.AdditionalVolumes {
-					volumeMount := corev1.VolumeMount{
-						Name:      avm.Name,
-						MountPath: avm.Path,
-					}
-					linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
-				}
-				if serviceTypeValues.Volumes.PersistentVolumeSize != "" {
-					volumeMount := corev1.VolumeMount{
-						Name:      serviceValues.PersistentVolumeName,
-						MountPath: serviceValues.PersistentVolumePath,
-					}
-					linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
-				}
-
-				for _, svm := range serviceTypeValues.SecondaryContainer.VolumeMounts {
-					volumeMount := corev1.VolumeMount{}
-					helpers.TemplateThings(tpld, svm, &volumeMount)
-					linkedContainer.Container.VolumeMounts = append(linkedContainer.Container.VolumeMounts, volumeMount)
-				}
-
-				// set the resource limit overrides if they are provided
-				if buildValues.Resources.Limits.Memory != "" {
-					if linkedContainer.Container.Resources.Limits == nil {
-						linkedContainer.Container.Resources.Limits = corev1.ResourceList{}
-					}
-					linkedContainer.Container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(buildValues.Resources.Limits.Memory)
-				}
-				if buildValues.Resources.Limits.EphemeralStorage != "" {
-					if linkedContainer.Container.Resources.Limits == nil {
-						linkedContainer.Container.Resources.Limits = corev1.ResourceList{}
-					}
-					linkedContainer.Container.Resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Limits.EphemeralStorage)
-				}
-				if buildValues.Resources.Requests.EphemeralStorage != "" {
-					if linkedContainer.Container.Resources.Requests == nil {
-						linkedContainer.Container.Resources.Requests = corev1.ResourceList{}
-					}
-					linkedContainer.Container.Resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(buildValues.Resources.Requests.EphemeralStorage)
-				}
-
-				deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, linkedContainer.Container)
 			}
 
 			// end deployment template

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -102,7 +102,7 @@ func GenerateDeploymentTemplate(
 			deployment.ObjectMeta.Annotations = annotations
 
 			// disable automounted service account
-			deployment.Spec.Template.Spec.AutomountServiceAccountToken = helpers.BoolPtr(false)
+			deployment.Spec.Template.Spec.AutomountServiceAccountToken = &buildValues.AutoMountServiceAccountToken
 
 			if serviceValues.UseSpotInstances {
 				// handle spot instance label and affinity/tolerations/selectors

--- a/internal/templating/templates_deployment.go
+++ b/internal/templating/templates_deployment.go
@@ -26,7 +26,7 @@ func GenerateDeploymentTemplate(
 	// for all the services that the build values generated
 	// iterate over them and generate any kubernetes deployments
 	for _, serviceValues := range checkedServices {
-		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok {
+		if val, ok := servicetypes.ServiceTypes[serviceValues.Type]; ok && serviceValues.Type != "external" {
 			serviceTypeValues := &servicetypes.ServiceType{}
 			helpers.DeepCopy(val, serviceTypeValues)
 

--- a/internal/templating/test-resources/deployment/result-node-1.yaml
+++ b/internal/templating/test-resources/deployment/result-node-1.yaml
@@ -60,7 +60,9 @@ spec:
         image: harbor.example.com/example-project/environment-name/node@latest
         imagePullPolicy: Always
         livenessProbe:
+          failureThreshold: 12
           initialDelaySeconds: 60
+          periodSeconds: 10
           tcpSocket:
             port: 3000
           timeoutSeconds: 10
@@ -151,7 +153,9 @@ spec:
         image: harbor.example.com/example-project/environment-name/node-persist@latest
         imagePullPolicy: Always
         livenessProbe:
+          failureThreshold: 12
           initialDelaySeconds: 60
+          periodSeconds: 10
           tcpSocket:
             port: 3000
           timeoutSeconds: 10

--- a/internal/templating/test-resources/deployment/result-redis-1.yaml
+++ b/internal/templating/test-resources/deployment/result-redis-1.yaml
@@ -142,6 +142,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0"
         - name: CRONJOBS

--- a/internal/testdata/basic/docker-compose.basic-externalservice.yml
+++ b/internal/testdata/basic/docker-compose.basic-externalservice.yml
@@ -1,0 +1,34 @@
+services:
+  basic1:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: basic
+      lagoon.service.port: 8080
+    ports:
+      - '8080'
+  basic2:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: external
+      # this service would be classed as an internal cluster externalname, the port to access it would be the same port
+      # as it would if it was running in the environment
+      lagoon.external.service: '{"name":"basic","project":"other-project","environment":"main"}'
+    ports:
+      # this is ignored by lagoon when the type is external
+      - '8181'
+  basic3:
+    build:
+      context: internal/testdata/basic/docker
+      dockerfile: basic.dockerfile
+    labels:
+      lagoon.type: external
+      # when defining an external service domain, the port may not be the same as if it was an internal cluster externalname
+      # the user would have to know more about the application and the external domain endpoint to know which port can be used
+      lagoon.external.service: '{"domain":"some-domain.example.com"}'
+    ports:
+      # this is ignored by lagoon when the type is external
+      - '8282' 

--- a/internal/testdata/basic/lagoon.externalservice.yml
+++ b/internal/testdata/basic/lagoon.externalservice.yml
@@ -1,0 +1,61 @@
+docker-compose-yaml: internal/testdata/basic/docker-compose.basic-externalservice.yml
+
+environment_variables:
+  git_sha: "true"
+
+environments:
+  main:
+    routes:
+      - node:
+          - example.com
+  stage:
+    routes:
+      - node:
+          - example.com
+    # this is an example of defining a simple network policy directly on an environment
+    network-policies:
+      # the name of the service you want to allow connections to
+      - service: basic1
+        organizations: 
+        # this allows anything in this organization
+        - name: example-org1
+
+# network-policies allow you to restrict which organizations, projects, or environments, can access a specific service
+# in the environment this policy is created in
+# network-policies only work if the environments are in the same cluster
+# this example is only to show how it could be used to create complex network policies if required
+# default network policies are to reject all ingress traffic from other lagoon environments
+# so all network policies are configured to allow from other environments only
+# there are some ways to exclude some traffic by setting policies that use exclude-projects or exclude-environments within
+# network-policies can also be defined under an environment in the environments section
+network-policies:
+  # the name of the service you want to allow connections to
+  - service: basic1
+    organizations: 
+    # this allows anything in this organization
+    - name: example-org1
+    # this allows anything in this organization from a production environment only
+    - name: example-org2
+      environment-type: production
+    # this allows anything in this organization except projects listed
+    - name: example-org3
+      exclude-projects:
+      - name: projecta
+      - name: projectb
+    projects:
+    # this allows anything from this projects main environment
+    - name: my-project1
+      environment: main
+    # this allows anything from this projects production environment
+    - name: my-project2
+      environment-type: production
+    # this allows anything from this project excluding specific environments
+    - name: my-project3
+      exclude-environments:
+      # these are the name of the environment from lagoon, not the escaped/safe versions used by machines
+      # the build-tool will handle conversions to the machine version as required
+      - name: feature/branch
+      - name: feature/environment-with-really-really-really-really-really-really-long-branch-name-that-will-truncate
+    # this allows anything from this project except pullrequest environment
+    - name: my-project4
+      exclude-pullrequests: true

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/deployment-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: stage
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: stage
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/stage/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/networkpolicy-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/networkpolicy-basic1.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org1
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic2.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic3.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service-environment/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: stage
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: stage
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/deployment-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/deployment-basic1.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: basic1
+      app.kubernetes.io/name: basic
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        lagoon.sh/branch: main
+        lagoon.sh/configMapSha: abcdefg1234567890
+        lagoon.sh/version: v2.7.x
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: basic1
+        app.kubernetes.io/managed-by: build-deploy-tool
+        app.kubernetes.io/name: basic
+        lagoon.sh/buildType: branch
+        lagoon.sh/environment: main
+        lagoon.sh/environmentType: production
+        lagoon.sh/project: example-project
+        lagoon.sh/service: basic1
+        lagoon.sh/service-type: basic
+        lagoon.sh/template: basic-0.1.0
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: LAGOON_GIT_SHA
+          value: abcdefg123456
+        - name: CRONJOBS
+        - name: SERVICE_NAME
+          value: basic1
+        envFrom:
+        - secretRef:
+            name: lagoon-platform-env
+        - secretRef:
+            name: lagoon-env
+        image: harbor.example/example-project/main/basic1@sha256:b2001babafaa8128fe89aa8fd11832cade59931d14c3de5b3ca32e2a010fbaa8
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 60
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 10
+        name: basic
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          initialDelaySeconds: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext: {}
+      enableServiceLinks: false
+      imagePullSecrets:
+      - name: lagoon-internal-registry-secret
+      priorityClassName: lagoon-priority-production
+status: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/networkpolicy-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/networkpolicy-basic1.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: service-network-policy
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: service-network-policy
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: network-policy
+    lagoon.sh/template: service-network-policy-0.1.0
+  name: basic1
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project1
+        - key: lagoon.sh/environment
+          operator: In
+          values:
+          - main
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project2
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project3
+        - key: lagoon.sh/environment
+          operator: NotIn
+          values:
+          - feature-branch
+          - feature-environment-with-really-really-rea-cd7d
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: lagoon.sh/project
+          operator: In
+          values:
+          - my-project4
+        - key: lagoon.sh/buildType
+          operator: NotIn
+          values:
+          - pullrequest
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org1
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org2
+        - key: lagoon.sh/environmentType
+          operator: In
+          values:
+          - production
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchExpressions:
+        - key: organization.lagoon.sh/name
+          operator: In
+          values:
+          - example-org3
+        - key: lagoon.sh/project
+          operator: NotIn
+          values:
+          - projecta
+          - projectb
+  podSelector:
+    matchLabels:
+      lagoon.sh/service: basic1

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic1.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic1.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: basic
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic1
+    lagoon.sh/service-type: basic
+    lagoon.sh/template: basic-0.1.0
+  name: basic1
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: basic1
+    app.kubernetes.io/name: basic
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic2.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic2.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic2
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic2
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic2
+spec:
+  externalName: basic.other-project-main.svc.cluster.local
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/basic/service-templates/test-basic-external-service/service-basic3.yaml
+++ b/internal/testdata/basic/service-templates/test-basic-external-service/service-basic3.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    lagoon.sh/branch: main
+    lagoon.sh/version: v2.7.x
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: basic3
+    app.kubernetes.io/managed-by: build-deploy-tool
+    app.kubernetes.io/name: external
+    lagoon.sh/buildType: branch
+    lagoon.sh/environment: main
+    lagoon.sh/environmentType: production
+    lagoon.sh/project: example-project
+    lagoon.sh/service: basic3
+    lagoon.sh/service-type: external
+    lagoon.sh/template: external-0.1.0
+  name: basic3
+spec:
+  externalName: some-domain.example.com
+  type: ExternalName
+status:
+  loadBalancer: {}

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-persist.yaml
@@ -51,6 +51,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS

--- a/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
+++ b/internal/testdata/complex/service-templates/test-complex-persistent-names/deployment-redis-session.yaml
@@ -51,6 +51,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: "0000000000000000000000000000000000000000"
         - name: CRONJOBS

--- a/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
+++ b/internal/testdata/complex/service-templates/test-redis-persistent-k8upv2/deployment-redis.yaml
@@ -50,6 +50,8 @@ spec:
       automountServiceAccountToken: false
       containers:
       - env:
+        - name: REDIS_FLAVOR
+          value: persistent
         - name: LAGOON_GIT_SHA
           value: abcdefg123456
         - name: CRONJOBS

--- a/legacy/build-deploy-docker-compose.sh
+++ b/legacy/build-deploy-docker-compose.sh
@@ -1597,7 +1597,7 @@ do
     fi
   done
 
-  if [[ $SERVICE_TYPE == *"-dbaas" ]]; then
+  if [[ $SERVICE_TYPE == *"-dbaas" ]] || [[ "$SERVICE_TYPE" == "external" ]]; then
     echo "nothing to monitor for $SERVICE_TYPE"
   else
     . /kubectl-build-deploy/scripts/exec-monitor-deploy.sh

--- a/legacy/docker-entrypoint.sh
+++ b/legacy/docker-entrypoint.sh
@@ -11,7 +11,9 @@ if [ $DOCKER_HOST_COUNTER -lt $DOCKER_HOST_TIMEOUT ]; then
     echo "${DOCKER_HOST} not available yet, waiting for 5 secs"
     sleep 5
 else
-    echo "could not connect to ${DOCKER_HOST}"
+    echo "Error: could not connect to ${DOCKER_HOST}"
+    echo "Please trigger another deployment."
+    echo "If the error persists please contact support."
     exit 1
 fi
 done


### PR DESCRIPTION
## Summary

- Merges upstream Lagoon build-deploy-tool v2.26.0 (core-v2.26.0 tag)
- **HIGH RISK merge** - Major refactor with pod spec consolidation into template_podspec.go
- Ports Tag1 customizations to new architecture

## Tag1 Customizations Preserved

- Custom tolerations from lagoon.tolerate docker-compose label
- Custom node selector from lagoon.nodeSelector docker-compose label
- Per-service resource requirements from lagoon.resources.* labels
- Per-service resource overrides for linked (secondary) containers

## Upstream Changes

- Pod spec consolidation into template_podspec.go
- External service type support
- Network policy collection

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds

## Tag

After merge: v2.26.0-tag1-0.2