### PR TITLE
ci: add AI PR review workflow with slash commands

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,128 @@
+# AI PR Review — automatic reviews on pull requests and slash commands.
+#
+# Secrets required:
+#   AI_REVIEW_API_KEY — Anthropic API key (or set ANTHROPIC_API_KEY)
+#   GH_TOKEN          — PAT with repo scope; required only for the /ai-pr-review
+#                       dismiss command's resolveReviewThread GraphQL mutation.
+#
+# Optional repo variables (Settings > Variables):
+#   AI_REVIEW_IMAGE_TAG       — container image tag (default: latest)
+#   AI_REVIEW_PROVIDER        — LLM provider (default: anthropic)
+#   AI_REVIEW_BASE_URL        — custom endpoint for bedrock-proxy
+#   AI_REVIEW_MODEL_STANDARD  — override standard model ID
+#   AI_REVIEW_MODEL_PREMIUM   — override premium model ID (full mode only)
+#   AI_REVIEW_IGNORE_MERGE_COMMITS — strip upstream base-branch merges (default: true)
+#   AI_REVIEW_EXCLUDE_ANALYZERS    — denylist analyzers to skip (comma-separated)
+#   AI_REVIEW_EXCLUDE_AGENTS       — denylist agents to skip (comma-separated)
+#
+# Slash commands (post as a PR comment):
+#   /ai-pr-review rescan          — force full diff re-review
+#   /ai-pr-review review-full     — run all agents (full mode)
+#   /ai-pr-review skip            — suppress the next automated review
+#   /ai-pr-review dismiss         — reply to an inline finding to dismiss it
+#   /ai-pr-review dismiss F<n>    — dismiss a body-level finding by stable ID
+#   /ai-pr-review false-positive [F<n>] [reason]
+#   /ai-pr-review wont-fix [F<n>] [reason]
+#   /ai-pr-review help            — post the command list
+
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run AI review
+        uses: tag1consulting/ai-pr-review/container-action@main
+        env:
+          FORCE_FULL_DIFF: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') }}
+        with:
+          image-tag: ${{ vars.AI_REVIEW_IMAGE_TAG || 'latest' }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
+          review-mode: >-
+            ${{
+              contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' ||
+              startsWith(github.event.pull_request.head.ref, 'release/') && 'full' ||
+              'quick'
+            }}
+          max-diff-lines: ${{ vars.AI_REVIEW_MAX_DIFF_LINES || '5000' }}
+          max-inline: ${{ vars.AI_REVIEW_MAX_INLINE || '25' }}
+          max-tokens-per-agent: ${{ vars.AI_REVIEW_MAX_TOKENS_PER_AGENT || '8192' }}
+          enable-suggestions: ${{ vars.AI_REVIEW_ENABLE_SUGGESTIONS || 'true' }}
+          parallel: ${{ vars.AI_REVIEW_PARALLEL || 'true' }}
+          ignore-merge-commits: ${{ vars.AI_REVIEW_IGNORE_MERGE_COMMITS || 'true' }}
+          context-enrichment: ${{ vars.AI_REVIEW_CONTEXT_ENRICHMENT || 'false' }}
+          exclude-patterns: ${{ vars.AI_REVIEW_EXCLUDE_PATTERNS || '' }}
+          exclude-patterns-mode: ${{ vars.AI_REVIEW_EXCLUDE_PATTERNS_MODE || 'append' }}
+          analyzer-diff-scope: ${{ vars.AI_REVIEW_ANALYZER_DIFF_SCOPE || 'cap' }}
+          feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}
+          analyzers: ${{ vars.AI_REVIEW_ANALYZERS || '' }}
+          exclude-analyzers: ${{ vars.AI_REVIEW_EXCLUDE_ANALYZERS || '' }}
+          agents: ${{ vars.AI_REVIEW_AGENTS || '' }}
+          exclude-agents: ${{ vars.AI_REVIEW_EXCLUDE_AGENTS || '' }}
+
+  slash-commands:
+    if: >-
+      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+      startsWith(github.event.comment.body, '/ai-pr-review') &&
+      contains(
+        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.comment.author_association
+      ) &&
+      (github.event_name == 'pull_request_review_comment' ||
+       (github.event_name == 'issue_comment' && github.event.issue.pull_request))
+    uses: tag1consulting/ai-pr-review/.github/workflows/slash-commands.yml@main
+    with:
+      event-name: ${{ github.event_name }}
+      comment-body: ${{ github.event.comment.body }}
+      comment-id: ${{ github.event.comment.id }}
+      comment-author-association: ${{ github.event.comment.author_association }}
+      issue-number: ${{ github.event.issue.number || '' }}
+      pr-number: ${{ github.event.pull_request.number || '' }}
+      in-reply-to-id: ${{ github.event.comment.in_reply_to_id || '' }}
+      is-pull-request: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+      repository: ${{ github.repository }}
+      repository-owner: ${{ github.repository_owner }}
+      repository-name: ${{ github.event.repository.name }}
+      actor-login: ${{ github.event.comment.user.login }}
+      provider: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
+      base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+      image-tag: ${{ vars.AI_REVIEW_IMAGE_TAG || 'latest' }}
+      review-mode-default: ${{ vars.AI_REVIEW_MODE_DEFAULT || 'quick' }}
+      enable-feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}
+      analyzers: ${{ vars.AI_REVIEW_ANALYZERS || '' }}
+      exclude-analyzers: ${{ vars.AI_REVIEW_EXCLUDE_ANALYZERS || '' }}
+      agents: ${{ vars.AI_REVIEW_AGENTS || '' }}
+      exclude-agents: ${{ vars.AI_REVIEW_EXCLUDE_AGENTS || '' }}
+    secrets:
+      api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.ANTHROPIC_API_KEY }}
+      github-token: ${{ secrets.GH_TOKEN }}
+      actions-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ai-pr-review.yml` to enable automatic LLM-based PR reviews on every pull request
- Wires up the full slash command suite via the reusable `slash-commands.yml` from `tag1consulting/ai-pr-review`
- Auto-selects full review mode for `release/*` branches (catches the upstream merge PRs)

## Secrets to configure

After this PR is merged, add the following in Settings > Secrets and variables > Actions:

| Secret | Value |
|--------|-------|
| `AI_REVIEW_API_KEY` | Anthropic API key |
| `GH_TOKEN` | PAT with `repo` scope (needed for `/ai-pr-review dismiss` to resolve review threads via GraphQL) |

## Available slash commands

Post these as PR comments (OWNER/MEMBER/COLLABORATOR only):

- `/ai-pr-review rescan` — force full diff re-review
- `/ai-pr-review review-full` — run all agents (full mode)
- `/ai-pr-review skip` — suppress the next automated review
- `/ai-pr-review dismiss` — reply to an inline finding to dismiss it (resolves thread; dismisses review when all threads cleared)
- `/ai-pr-review dismiss F<n>` — dismiss a body-level finding by stable ID
- `/ai-pr-review false-positive [F<n>] [reason]` — record a false-positive verdict
- `/ai-pr-review wont-fix [F<n>] [reason]` — record a won't-fix verdict
- `/ai-pr-review help` — post the command list

## Test plan

- [ ] PR opened against `tag1-main` triggers the `review` job
- [ ] Draft PRs are skipped (no review fires)
- [ ] `/ai-pr-review help` posted as a PR comment replies with the command list
- [ ] `/ai-pr-review rescan` re-runs the review
- [ ] `release/*` branches get `full` mode automatically