### PR TITLE
Merge upstream core-v2.33.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 A modified version of build-deploy-tool with some added functionality allowing lagoon docker-compose service labels to
 specify resource requirements of service.
 
-Branch `upstream` is to be kept up with upstream main. `tag1-main` is release branch for tested changes ready to go.
-Default branch `tag1-dev` may be unstable or broken.
+Branch `upstream` is to be kept up with upstream main. `tag1-main` is release branch for tested changes ready to go, and is also this repo's GitHub default branch.
+Branch `tag1-dev` exists but is stale (well behind `tag1-main`) as of this writing; do not treat it as the default.
 
 
 Image may be built and push to ghcr.io by pushing a tag. We should version our tags off of the current upstream version changes are based on.
-Currently this is `core-v2.21.0` upstream, so should do something like: `v2.21.0-tag1-0.1` (keep our versioning after `v2.21.0-tag1-` prefix).
+Currently this is `core-v2.33.0` upstream, so should do something like: `v2.33.0-tag1-0.1` (keep our versioning after `v2.33.0-tag1-` prefix).
 
 ## Usage
 
@@ -40,7 +40,7 @@ The deploy target (`lagoon list deploytargets`) has a buildimage override field 
 See available image tags here: https://github.com/tag1consulting/lagoon-build-deploy-tool/pkgs/container/build-deploy-image
 
 ```bash
-lagoon update deploytargets --id <id> --build-image 'ghcr.io/tag1consulting/build-deploy-image:v2.21.0-tag1-0.1'
+lagoon update deploytargets --id <id> --build-image 'ghcr.io/tag1consulting/build-deploy-image:v2.33.0-tag1-0.1'
 ```
 lagoon list projects can be used to verify project is associate with a given deploytarget.
 

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -461,7 +461,7 @@ func calculateMetric(times mapset.Set[int]) (int, error) {
 	}
 
 	if times.Cardinality() == 1 {
-		return times.ToSlice()[0], nil
+		return 1440, nil
 	}
 
 	// Sort the times

--- a/internal/cron/cron_test.go
+++ b/internal/cron/cron_test.go
@@ -94,6 +94,11 @@ func TestStandardizeSchedule(t *testing.T) {
 			cron: "M/30 17/12,0-23 * * *",
 			want: "23,53 17/12,0-23 * * *",
 		},
+		{
+			name: "test26",
+			cron: "0 0 * * *",
+			want: "0 0 * * *",
+		},
 	}
 
 	for _, tt := range tests {
@@ -381,6 +386,13 @@ func TestDecideRunner(t *testing.T) {
 			},
 			expectedInPod: helpers.BoolPtr(true),
 		},
+		{
+			name: "InPod22",
+			cronjob: Cronjob{
+				Schedule: "0 0 * * *",
+			},
+			expectedInPod: helpers.BoolPtr(false),
+		},
 	}
 
 	for _, tt := range tests {
@@ -428,12 +440,16 @@ func TestCalculateMetric(t *testing.T) {
 		{
 			name:     "one element",
 			input:    []int{300}, // median of a single element is itself
-			expected: 300,
+			expected: 1440,
 		},
 		{
 			name:    "empty set",
 			input:   []int{},
 			wantErr: true,
+		}, {
+			name:     "one element at midnight",
+			input:    []int{0}, // 0 0 * * *
+			expected: 1440,
 		},
 	}
 
@@ -449,6 +465,53 @@ func TestCalculateMetric(t *testing.T) {
 
 			if !tt.wantErr && got != tt.expected {
 				t.Errorf("expected %d, got %d", tt.expected, got)
+			}
+		})
+	}
+}
+
+func Test_calculateScheduleMetric(t *testing.T) {
+	tests := []struct {
+		name     string
+		schedule string
+		want     int
+		wantErr  bool
+	}{
+		{
+			name:     "test1",
+			schedule: "0 0 * * *",
+			want:     1440,
+		},
+		{
+			name:     "test2",
+			schedule: "0 * * * *",
+			want:     60,
+		},
+		{
+			name:     "test3",
+			schedule: "3,8,13,18,23,28,33,38,43,48,53,58 * * * *",
+			want:     5,
+		},
+		{
+			name:     "test4",
+			schedule: "1 1 * * *",
+			want:     1440,
+		},
+		{
+			name:     "test5",
+			schedule: "* * * * *",
+			want:     1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := calculateScheduleMetric(tt.schedule)
+			if (gotErr != nil) != tt.wantErr {
+				t.Fatalf("expected error=%v, got error=%v", tt.wantErr, gotErr != nil)
+			}
+
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("expected %d, got %d", tt.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Merges upstream `uselagoon/build-deploy-tool` tag `core-v2.33.0` into `tag1-main`. Clean merge, no conflicts. Upstream delta (`core-v2.32.0` -> `core-v2.33.0`) brings in:

- `fix: cron first element single value minute return (#506)`
- `feat: support username password in http giturls (#426)`

All tag1-specific patches carried forward unchanged: GoReleaser `--clean` flag, renovate `baseBranches: tag1-main`, and the ai-pr-review workflow.

## Docs

Updated `README.md`'s stale version references (`core-v2.21.0` -> `core-v2.33.0`, and the corresponding `v2.21.0-tag1-0.1` example tag -> `v2.33.0-tag1-0.1`). Also corrected the README's default-branch claim: it names `tag1-dev` as default, but GitHub's actual default branch is `tag1-main`, and `tag1-dev` is 120 commits behind as of this writing.

## Verification

- `go build ./...` — succeeds, no errors.
- `go test ./...` — 737 passed, 16 packages, no failures.

## Out of scope

This PR does **not** address the two open High-severity Dependabot alerts (#5, #6) on `github.com/distribution/distribution/v3` (fixed in `v3.1.0`, currently pinned to a pre-2021 commit). That fix is being tracked as a separate, focused PR per an explicit decision to keep the security bump independent of this upstream merge.

## Next steps

Once merged, this needs a version tag (`v2.33.0-tag1-0.1`) and a GitHub release per the fork's versioning convention -- both are separate checkpoints, not part of this PR.